### PR TITLE
Proper Struct syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- [6](https://github.com/cheddar-me/pecorino/pull/6) - Changed the way Structs are defined, this does not impact the API.
+
 ## [0.1.0] - 2023-10-30
 
 - Initial release

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -25,7 +25,7 @@
 # The storage use is one DB row per leaky bucket you need to manage (likely - one throttled entity such
 # as a combination of an IP address + the URL you need to procect). The `key` is an arbitrary string you provide.
 class Pecorino::LeakyBucket
-  class State < Struct.new(:level, :full)
+  State = Struct.new(:level, :full) do
     # Returns the level of the bucket after the operation on the LeakyBucket
     # object has taken place. There is a guarantee that no tokens have leaked
     # from the bucket between the operation and the freezing of the State

--- a/lib/pecorino/throttle.rb
+++ b/lib/pecorino/throttle.rb
@@ -6,7 +6,7 @@
 # the block is lifted. The block time can be arbitrarily higher or lower than the amount
 # of time it takes for the leaky bucket to leak out
 class Pecorino::Throttle
-  class State < Struct.new(:blocked_until)
+  State = Struct.new(:blocked_until) do
     # Tells whether this throttle is blocked, either due to the leaky bucket having filled up
     # or due to there being a timed block set because of an earlier event of the bucket having
     # filled up


### PR DESCRIPTION
Struct.new already subclasses, the other syntax creates an anonymous subclcass in the ancestor chain and makes Tapioca overlook the setters/getters defined in the arguments when generating signatures (https://github.com/Shopify/tapioca/issues/1384)