### PR TITLE
Remove delta comparison for fillup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- [8](https://github.com/cheddar-me/pecorino/pull/8) - Use comparisons in SQL to determine whether the leaky bucket did overflow
 - [6](https://github.com/cheddar-me/pecorino/pull/6) - Changed the way Structs are defined, this does not impact the API.
 
 ## [0.1.0] - 2023-10-30

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -181,7 +181,7 @@ class Pecorino::LeakyBucket
       RETURNING
         level,
         -- Compare level to the capacity inside the DB so that we won't have rounding issues
-        level >= :capa AS did_fillup
+        level >= :capa AS did_overflow
     SQL
 
     # Note the use of .uncached here. The AR query cache will actually see our
@@ -189,8 +189,8 @@ class Pecorino::LeakyBucket
     # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
     # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
     upserted = conn.uncached { conn.select_one(sql) }
-    capped_level_after_fillup, did_fillup = upserted.fetch("level"), upserted.fetch("did_fillup")
+    capped_level_after_fillup, did_overflow = upserted.fetch("level"), upserted.fetch("did_overflow")
 
-    State.new(capped_level_after_fillup, did_fillup)
+    State.new(capped_level_after_fillup, did_overflow)
   end
 end

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -178,15 +178,19 @@ class Pecorino::LeakyBucket
               t.level + :fillup - (EXTRACT(EPOCH FROM (EXCLUDED.last_touched_at - t.last_touched_at)) * :leak_rate)
           )
         )
-      RETURNING level
+      RETURNING
+        level,
+        -- Compare level to the capacity inside the DB so that we won't have rounding issues
+        level >= :capa AS did_fillup
     SQL
 
     # Note the use of .uncached here. The AR query cache will actually see our
-    # query as a repeat (since we use "select_value" for the RETURNING bit) and will not call into Postgres
+    # query as a repeat (since we use "select_one" for the RETURNING bit) and will not call into Postgres
     # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
     # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
-    level_after_fillup = conn.uncached { conn.select_value(sql) }
+    upserted = conn.uncached { conn.select_one(sql) }
+    capped_level_after_fillup, did_fillup = upserted.fetch("level"), upserted.fetch("did_fillup")
 
-    State.new(level_after_fillup, (@capacity - level_after_fillup).abs < 0.01)
+    State.new(capped_level_after_fillup, did_fillup)
   end
 end


### PR DESCRIPTION
It is better to let the DB compare the level to the capacity (using it's own float representation) and to return based on that. Since we use LEAST the value would be equal (exactly) to capacity at overflow.

Closes #7