### PR TITLE
Add SQLite support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [Unreleased]
 
-- [8](https://github.com/cheddar-me/pecorino/pull/8) - Use comparisons in SQL to determine whether the leaky bucket did overflow
-- [6](https://github.com/cheddar-me/pecorino/pull/6) - Changed the way Structs are defined, this does not impact the API.
+- [Add support for SQLite](https://github.com/cheddar-me/pecorino/pull/9)
+- [Use comparisons in SQL to determine whether the leaky bucket did overflow](https://github.com/cheddar-me/pecorino/pull/8)
+- [Change the way Structs are defined to appease Tapioca/Sorbet](https://github.com/cheddar-me/pecorino/pull/6)
 
 ## [0.1.0] - 2023-10-30
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pecorino is a rate limiter based on the concept of leaky buckets. It uses your DB as the storage backend for the throttles. It is compact, easy to install, and does not require additional infrastructure. The approach used by Pecorino has been previously used by [prorate](https://github.com/WeTransfer/prorate) with Redis, and that approach has proven itself.
 
-Pecorino is designed to integrate seamlessly into any Rails application using a Postgres database (at the moment there is no MySQL support, we would be delighted if you could add it).
+Pecorino is designed to integrate seamlessly into any Rails application using a PostgreSQL or SQLite database (at the moment there is no MySQL support, we would be delighted if you could add it).
 
 If you would like to know more about the leaky bucket algorithm: [this article](http://live.julik.nl/2022/08/the-unreasonable-effectiveness-of-leaky-buckets) or the [Wikipedia article](https://en.wikipedia.org/wiki/Leaky_bucket) are both good starting points.
 
@@ -87,7 +87,7 @@ We recommend running the following bit of code every couple of hours (via cron o
 Pecorino.prune!
 ```
 
-## Using unlogged tables for reduced replication load
+## Using unlogged tables for reduced replication load (PostgreSQL)
 
 Throttles and leaky buckets are transient resources. If you are using Postgres replication, it might be prudent to set the Pecorino tables to `UNLOGGED` which will exclude them from replication - and save you bandwidth and storage on your RR. To do so, add the following statements to your migration:
 

--- a/lib/pecorino.rb
+++ b/lib/pecorino.rb
@@ -38,11 +38,7 @@ module Pecorino
     active_record_schema.create_table :pecorino_leaky_buckets, id: :uuid do |t|
       t.string :key, null: false
       t.float :level, null: false
-      if active_record_schema.connection.adapter_name =~ /sqlite/
-        t.text :last_touched_at, null: false
-      else
-        t.datetime :last_touched_at, null: false
-      end
+      t.datetime :last_touched_at, null: false
       t.datetime :may_be_deleted_after, null: false
     end
     active_record_schema.add_index :pecorino_leaky_buckets, [:key], unique: true

--- a/lib/pecorino.rb
+++ b/lib/pecorino.rb
@@ -6,11 +6,12 @@ require "active_record/sanitization"
 require_relative "pecorino/version"
 require_relative "pecorino/leaky_bucket"
 require_relative "pecorino/throttle"
-require_relative "pecorino/postgres"
-require_relative "pecorino/sqlite"
 require_relative "pecorino/railtie" if defined?(Rails::Railtie)
 
 module Pecorino
+  autoload :Postgres, "pecorino/postgres"
+  autoload :Sqlite, "pecorino/sqlite"
+
   # Deletes stale leaky buckets and blocks which have expired. Run this method regularly to
   # avoid accumulating too many unused rows in your tables.
   #

--- a/lib/pecorino.rb
+++ b/lib/pecorino.rb
@@ -7,6 +7,7 @@ require_relative "pecorino/version"
 require_relative "pecorino/leaky_bucket"
 require_relative "pecorino/throttle"
 require_relative "pecorino/postgres"
+require_relative "pecorino/sqlite"
 require_relative "pecorino/railtie" if defined?(Rails::Railtie)
 
 module Pecorino

--- a/lib/pecorino.rb
+++ b/lib/pecorino.rb
@@ -51,4 +51,20 @@ module Pecorino
     active_record_schema.add_index :pecorino_blocks, [:key], unique: true
     active_record_schema.add_index :pecorino_blocks, [:blocked_until]
   end
+
+  # Returns the database implementation for setting the values atomically. Since the implementation
+  # differs per database, this method will return a different adapter depending on which database is
+  # being used
+  def self.adapter
+    model_class = ActiveRecord::Base
+    adapter_name = model_class.connection.adapter_name
+    case adapter_name
+    when /postgres/i
+      Pecorino::Postgres.new(model_class)
+    when /sqlite/i
+      Pecorino::Sqlite.new(model_class)
+    else
+      raise "Pecorino does not support #{adapter_name} just yet"
+    end
+  end
 end

--- a/lib/pecorino.rb
+++ b/lib/pecorino.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require "active_support/concern"
+require "active_record/sanitization"
+
 require_relative "pecorino/version"
 require_relative "pecorino/leaky_bucket"
 require_relative "pecorino/throttle"
+require_relative "pecorino/postgres"
 require_relative "pecorino/railtie" if defined?(Rails::Railtie)
 
 module Pecorino

--- a/lib/pecorino.rb
+++ b/lib/pecorino.rb
@@ -38,7 +38,11 @@ module Pecorino
     active_record_schema.create_table :pecorino_leaky_buckets, id: :uuid do |t|
       t.string :key, null: false
       t.float :level, null: false
-      t.datetime :last_touched_at, null: false
+      if active_record_schema.connection.adapter_name =~ /sqlite/
+        t.text :last_touched_at, null: false
+      else
+        t.datetime :last_touched_at, null: false
+      end
       t.datetime :may_be_deleted_after, null: false
     end
     active_record_schema.add_index :pecorino_leaky_buckets, [:key], unique: true

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -114,6 +114,14 @@ class Pecorino::LeakyBucket
   private
 
   def database_implementation
-    Pecorino::Postgres
+    adapter_name = ActiveRecord::Base.connection.adapter_name
+    case adapter_name
+    when /postgres/i
+      Pecorino::Postgres
+    when /sqlite/i
+      Pecorino::Sqlite
+    else
+      raise "Pecorino does not support #{adapter_name} just yet"
+    end
   end
 end

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -86,7 +86,7 @@ class Pecorino::LeakyBucket
   # @param n_tokens[Float]
   # @return [State] the state of the bucket after the operation
   def fillup(n_tokens)
-    capped_level_after_fillup, did_overflow = database_implementation.add_tokens(capa: @capacity, key: @key, leak_rate: @leak_rate, n_tokens: n_tokens)
+    capped_level_after_fillup, did_overflow = Pecorino.adapter.add_tokens(capa: @capacity, key: @key, leak_rate: @leak_rate, n_tokens: n_tokens)
     State.new(capped_level_after_fillup, did_overflow)
   end
 
@@ -95,7 +95,7 @@ class Pecorino::LeakyBucket
   #
   # @return [State] the snapshotted state of the bucket at time of query
   def state
-    current_level, is_full = database_implementation.state(key: @key, capa: @capacity, leak_rate: @leak_rate)
+    current_level, is_full = Pecorino.adapter.state(key: @key, capa: @capacity, leak_rate: @leak_rate)
     State.new(current_level, is_full)
   end
 
@@ -109,20 +109,5 @@ class Pecorino::LeakyBucket
   # @return [boolean]
   def able_to_accept?(n_tokens)
     (state.level + n_tokens) < @capacity
-  end
-
-  private
-
-  def database_implementation
-    model_class = ActiveRecord::Base
-    adapter_name = model_class.connection.adapter_name
-    case adapter_name
-    when /postgres/i
-      Pecorino::Postgres.new(ActiveRecord::Base)
-    when /sqlite/i
-      Pecorino::Sqlite.new(ActiveRecord::Base)
-    else
-      raise "Pecorino does not support #{adapter_name} just yet"
-    end
   end
 end

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -86,7 +86,7 @@ class Pecorino::LeakyBucket
   # @param n_tokens[Float]
   # @return [State] the state of the bucket after the operation
   def fillup(n_tokens)
-    capped_level_after_fillup, did_overflow = Pecorino.adapter.add_tokens(capa: @capacity, key: @key, leak_rate: @leak_rate, n_tokens: n_tokens)
+    capped_level_after_fillup, did_overflow = Pecorino.adapter.add_tokens(capacity: @capacity, key: @key, leak_rate: @leak_rate, n_tokens: n_tokens)
     State.new(capped_level_after_fillup, did_overflow)
   end
 
@@ -95,7 +95,7 @@ class Pecorino::LeakyBucket
   #
   # @return [State] the snapshotted state of the bucket at time of query
   def state
-    current_level, is_full = Pecorino.adapter.state(key: @key, capa: @capacity, leak_rate: @leak_rate)
+    current_level, is_full = Pecorino.adapter.state(key: @key, capacity: @capacity, leak_rate: @leak_rate)
     State.new(current_level, is_full)
   end
 

--- a/lib/pecorino/postgres.rb
+++ b/lib/pecorino/postgres.rb
@@ -102,17 +102,5 @@ module Pecorino::Postgres
     conn.uncached { conn.select_value(block_set_query) }
   end
 
-  private
-
-  def sanitize_sql_array_via_connection(connection, ...)
-    # TODO: terrible hack
-    sanitizer = begin
-      struct_class = Struct.new(:connection)
-      struct_class.send(:include, ActiveRecord::Sanitization::ClassMethods)
-      struct_class.new(connection)
-    end
-    sanitizer.sanitize_sql_array(...)
-  end
-
   extend self
 end

--- a/lib/pecorino/postgres.rb
+++ b/lib/pecorino/postgres.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Pecorino::Postgres
+  class Sanitizer < Struct.new(:connection)
+    include ActiveRecord::Sanitization::ClassMethods
+  end
+
+  def state(conn:, key:, capa:, leak_rate:)
+    query_params = {
+      key: key.to_s,
+      capa: capa.to_f,
+      leak_rate: leak_rate.to_f
+    }
+    # The `level` of the bucket is what got stored at `last_touched_at` time, and we can
+    # extrapolate from it to see how many tokens have leaked out since `last_touched_at` -
+    # we don't need to UPDATE the value in the bucket here
+    sql = Sanitizer.new(conn).sanitize_sql_array([<<~SQL, query_params])
+      SELECT
+        GREATEST(
+          0.0, LEAST(
+            :capa,
+            t.level - (EXTRACT(EPOCH FROM (clock_timestamp() - t.last_touched_at)) * :leak_rate)
+          )
+        )
+      FROM 
+        pecorino_leaky_buckets AS t
+      WHERE
+        key = :key
+    SQL
+
+    # If the return value of the query is a NULL it means no such bucket exists,
+    # so we assume the bucket is empty
+    current_level = conn.uncached { conn.select_value(sql) } || 0.0
+    [current_level, capa - current_level.abs < 0.01]
+  end
+
+  def add_tokens(conn:, key:, capa:, leak_rate:, n_tokens:)
+    # Take double the time it takes the bucket to empty under normal circumstances
+    # until the bucket may be deleted.
+    may_be_deleted_after_seconds = (capa.to_f / leak_rate.to_f) * 2.0
+
+    # Create the leaky bucket if it does not exist, and update
+    # to the new level, taking the leak rate into account - if the bucket exists.
+    query_params = {
+      key: key.to_s,
+      capa: capa.to_f,
+      delete_after_s: may_be_deleted_after_seconds,
+      leak_rate: leak_rate.to_f,
+      fillup: n_tokens.to_f
+    }
+
+    sql = Sanitizer.new(conn).sanitize_sql_array([<<~SQL, query_params])
+      INSERT INTO pecorino_leaky_buckets AS t
+        (key, last_touched_at, may_be_deleted_after, level)
+      VALUES
+        (
+          :key,
+          clock_timestamp(),
+          clock_timestamp() + ':delete_after_s second'::interval,
+          GREATEST(0.0,
+            LEAST(
+              :capa,
+              :fillup
+            )
+          )
+        )
+      ON CONFLICT (key) DO UPDATE SET
+        last_touched_at = EXCLUDED.last_touched_at,
+        may_be_deleted_after = EXCLUDED.may_be_deleted_after,
+        level = GREATEST(0.0,
+          LEAST(
+              :capa,
+              t.level + :fillup - (EXTRACT(EPOCH FROM (EXCLUDED.last_touched_at - t.last_touched_at)) * :leak_rate)
+          )
+        )
+      RETURNING
+        level,
+        -- Compare level to the capacity inside the DB so that we won't have rounding issues
+        level >= :capa AS did_overflow
+    SQL
+
+    # Note the use of .uncached here. The AR query cache will actually see our
+    # query as a repeat (since we use "select_one" for the RETURNING bit) and will not call into Postgres
+    # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
+    # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
+    upserted = conn.uncached { conn.select_one(sql) }
+    capped_level_after_fillup, did_overflow = upserted.fetch("level"), upserted.fetch("did_overflow")
+    [capped_level_after_fillup, did_overflow]
+  end
+
+  def set_block(conn:, key:, block_for:)
+    query_params = {key: key.to_s, block_for: block_for.to_f}
+    block_set_query = Sanitizer.new(conn).sanitize_sql_array([<<~SQL, query_params])
+      INSERT INTO pecorino_blocks AS t
+        (key, blocked_until)
+      VALUES
+        (:key, NOW() + ':block_for seconds'::interval)
+      ON CONFLICT (key) DO UPDATE SET
+        blocked_until = GREATEST(EXCLUDED.blocked_until, t.blocked_until)
+      RETURNING blocked_until;
+    SQL
+    conn.uncached { conn.select_value(block_set_query) }
+  end
+
+  private
+
+  def sanitize_sql_array_via_connection(connection, ...)
+    # TODO: terrible hack
+    sanitizer = begin
+      struct_class = Struct.new(:connection)
+      struct_class.send(:include, ActiveRecord::Sanitization::ClassMethods)
+      struct_class.new(connection)
+    end
+    sanitizer.sanitize_sql_array(...)
+  end
+
+  extend self
+end

--- a/lib/pecorino/postgres.rb
+++ b/lib/pecorino/postgres.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Pecorino::Postgres < Struct.new(:model_class)
+Pecorino::Postgres = Struct.new(:model_class) do
   def state(key:, capa:, leak_rate:)
     query_params = {
       key: key.to_s,

--- a/lib/pecorino/postgres.rb
+++ b/lib/pecorino/postgres.rb
@@ -99,7 +99,6 @@ class Pecorino::Postgres < Struct.new(:model_class)
   end
 
   def blocked_until(key:)
-    # This query is database-agnostic, so it is not in the various database modules
     block_check_query = model_class.sanitize_sql_array([<<~SQL, key])
       SELECT blocked_until FROM pecorino_blocks WHERE key = ? AND blocked_until >= NOW() LIMIT 1
     SQL

--- a/lib/pecorino/postgres.rb
+++ b/lib/pecorino/postgres.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-module Pecorino::Postgres
-  class Sanitizer < Struct.new(:connection)
-    include ActiveRecord::Sanitization::ClassMethods
-  end
-
-  def state(conn:, key:, capa:, leak_rate:)
+class Pecorino::Postgres < Struct.new(:model_class)
+  def state(key:, capa:, leak_rate:)
     query_params = {
       key: key.to_s,
       capa: capa.to_f,
@@ -14,7 +10,7 @@ module Pecorino::Postgres
     # The `level` of the bucket is what got stored at `last_touched_at` time, and we can
     # extrapolate from it to see how many tokens have leaked out since `last_touched_at` -
     # we don't need to UPDATE the value in the bucket here
-    sql = Sanitizer.new(conn).sanitize_sql_array([<<~SQL, query_params])
+    sql = model_class.sanitize_sql_array([<<~SQL, query_params])
       SELECT
         GREATEST(
           0.0, LEAST(
@@ -30,11 +26,11 @@ module Pecorino::Postgres
 
     # If the return value of the query is a NULL it means no such bucket exists,
     # so we assume the bucket is empty
-    current_level = conn.uncached { conn.select_value(sql) } || 0.0
+    current_level = model_class.connection.uncached { model_class.connection.select_value(sql) } || 0.0
     [current_level, capa - current_level.abs < 0.01]
   end
 
-  def add_tokens(conn:, key:, capa:, leak_rate:, n_tokens:)
+  def add_tokens(key:, capa:, leak_rate:, n_tokens:)
     # Take double the time it takes the bucket to empty under normal circumstances
     # until the bucket may be deleted.
     may_be_deleted_after_seconds = (capa.to_f / leak_rate.to_f) * 2.0
@@ -49,7 +45,7 @@ module Pecorino::Postgres
       fillup: n_tokens.to_f
     }
 
-    sql = Sanitizer.new(conn).sanitize_sql_array([<<~SQL, query_params])
+    sql = model_class.sanitize_sql_array([<<~SQL, query_params])
       INSERT INTO pecorino_leaky_buckets AS t
         (key, last_touched_at, may_be_deleted_after, level)
       VALUES
@@ -83,14 +79,14 @@ module Pecorino::Postgres
     # query as a repeat (since we use "select_one" for the RETURNING bit) and will not call into Postgres
     # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
     # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
-    upserted = conn.uncached { conn.select_one(sql) }
+    upserted = model_class.connection.uncached { model_class.connection.select_one(sql) }
     capped_level_after_fillup, did_overflow = upserted.fetch("level"), upserted.fetch("did_overflow")
     [capped_level_after_fillup, did_overflow]
   end
 
-  def set_block(conn:, key:, block_for:)
+  def set_block(key:, block_for:)
     query_params = {key: key.to_s, block_for: block_for.to_f}
-    block_set_query = Sanitizer.new(conn).sanitize_sql_array([<<~SQL, query_params])
+    block_set_query = model_class.sanitize_sql_array([<<~SQL, query_params])
       INSERT INTO pecorino_blocks AS t
         (key, blocked_until)
       VALUES
@@ -99,8 +95,14 @@ module Pecorino::Postgres
         blocked_until = GREATEST(EXCLUDED.blocked_until, t.blocked_until)
       RETURNING blocked_until;
     SQL
-    conn.uncached { conn.select_value(block_set_query) }
+    model_class.connection.uncached { model_class.connection.select_value(block_set_query) }
   end
 
-  extend self
+  def blocked_until(key:)
+    # This query is database-agnostic, so it is not in the various database modules
+    block_check_query = model_class.sanitize_sql_array([<<~SQL, key])
+      SELECT blocked_until FROM pecorino_blocks WHERE key = ? AND blocked_until >= NOW() LIMIT 1
+    SQL
+    model_class.connection.uncached { model_class.connection.select_value(block_check_query) }
+  end
 end

--- a/lib/pecorino/sqlite.rb
+++ b/lib/pecorino/sqlite.rb
@@ -55,8 +55,8 @@ module Pecorino::Sqlite
       VALUES
         (
           :key,
-          clock_timestamp(),
-          clock_timestamp() + ':delete_after_s second'::interval,
+          DATETIME('now'),
+          DATETIME('now') + ':delete_after_s second'::interval,
           MAX(0.0,
             MIN(
               :capa,
@@ -70,7 +70,7 @@ module Pecorino::Sqlite
         level = MAX(0.0,
           MIN(
               :capa,
-              t.level + :fillup - (EXTRACT(EPOCH FROM (EXCLUDED.last_touched_at - t.last_touched_at)) * :leak_rate)
+              t.level + :fillup - (UNIXEPOCH(DATETIME('now')) - UNIXEPOCH(t.last_touched_at)) * :leak_rate
           )
         )
       RETURNING

--- a/lib/pecorino/sqlite.rb
+++ b/lib/pecorino/sqlite.rb
@@ -102,17 +102,5 @@ module Pecorino::Sqlite
     conn.uncached { conn.select_value(block_set_query) }
   end
 
-  private
-
-  def sanitize_sql_array_via_connection(connection, ...)
-    # TODO: terrible hack
-    sanitizer = begin
-      struct_class = Struct.new(:connection)
-      struct_class.send(:include, ActiveRecord::Sanitization::ClassMethods)
-      struct_class.new(connection)
-    end
-    sanitizer.sanitize_sql_array(...)
-  end
-
   extend self
 end

--- a/lib/pecorino/sqlite.rb
+++ b/lib/pecorino/sqlite.rb
@@ -76,7 +76,7 @@ module Pecorino::Sqlite
         (
           :id,
           :key,
-          DATETIME('now'), -- Precision loss must be avoided here as it is used for calculations
+          strftime('%Y-%m-%d %H:%M:%f'), -- Precision loss must be avoided here as it is used for calculations
           DATETIME('now', '+:delete_after_s seconds'), -- Precision loss is acceptable here
           MAX(0.0,
             MIN(

--- a/lib/pecorino/sqlite.rb
+++ b/lib/pecorino/sqlite.rb
@@ -76,8 +76,8 @@ module Pecorino::Sqlite
         (
           :id,
           :key,
-          DATETIME('now'),
-          DATETIME('now', '+:delete_after_s seconds'),
+          DATETIME('now'), -- Precision loss must be avoided here as it is used for calculations
+          DATETIME('now', '+:delete_after_s seconds'), -- Precision loss is acceptable here
           MAX(0.0,
             MIN(
               :capa,
@@ -115,7 +115,7 @@ module Pecorino::Sqlite
       INSERT INTO pecorino_blocks AS t
         (key, blocked_until)
       VALUES
-        (:key, NOW() + ':block_for seconds'::interval)
+        (:key, DATETIME() + ':block_for seconds'::interval)
       ON CONFLICT (key) DO UPDATE SET
         blocked_until = MAX(EXCLUDED.blocked_until, t.blocked_until)
       RETURNING blocked_until;

--- a/lib/pecorino/sqlite.rb
+++ b/lib/pecorino/sqlite.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Pecorino::Sqlite
+  class Sanitizer < Struct.new(:connection)
+    include ActiveRecord::Sanitization::ClassMethods
+  end
+
+  def state(conn:, key:, capa:, leak_rate:)
+    query_params = {
+      key: key.to_s,
+      capa: capa.to_f,
+      leak_rate: leak_rate.to_f
+    }
+    # The `level` of the bucket is what got stored at `last_touched_at` time, and we can
+    # extrapolate from it to see how many tokens have leaked out since `last_touched_at` -
+    # we don't need to UPDATE the value in the bucket here
+    sql = Sanitizer.new(conn).sanitize_sql_array([<<~SQL, query_params])
+      SELECT
+        GREATEST(
+          0.0, LEAST(
+            :capa,
+            t.level - (EXTRACT(EPOCH FROM (clock_timestamp() - t.last_touched_at)) * :leak_rate)
+          )
+        )
+      FROM 
+        pecorino_leaky_buckets AS t
+      WHERE
+        key = :key
+    SQL
+
+    # If the return value of the query is a NULL it means no such bucket exists,
+    # so we assume the bucket is empty
+    current_level = conn.uncached { conn.select_value(sql) } || 0.0
+    [current_level, capa - current_level.abs < 0.01]
+  end
+
+  def add_tokens(conn:, key:, capa:, leak_rate:, n_tokens:)
+    # Take double the time it takes the bucket to empty under normal circumstances
+    # until the bucket may be deleted.
+    may_be_deleted_after_seconds = (capa.to_f / leak_rate.to_f) * 2.0
+
+    # Create the leaky bucket if it does not exist, and update
+    # to the new level, taking the leak rate into account - if the bucket exists.
+    query_params = {
+      key: key.to_s,
+      capa: capa.to_f,
+      delete_after_s: may_be_deleted_after_seconds,
+      leak_rate: leak_rate.to_f,
+      fillup: n_tokens.to_f
+    }
+
+    sql = Sanitizer.new(conn).sanitize_sql_array([<<~SQL, query_params])
+      INSERT INTO pecorino_leaky_buckets AS t
+        (key, last_touched_at, may_be_deleted_after, level)
+      VALUES
+        (
+          :key,
+          clock_timestamp(),
+          clock_timestamp() + ':delete_after_s second'::interval,
+          GREATEST(0.0,
+            LEAST(
+              :capa,
+              :fillup
+            )
+          )
+        )
+      ON CONFLICT (key) DO UPDATE SET
+        last_touched_at = EXCLUDED.last_touched_at,
+        may_be_deleted_after = EXCLUDED.may_be_deleted_after,
+        level = GREATEST(0.0,
+          LEAST(
+              :capa,
+              t.level + :fillup - (EXTRACT(EPOCH FROM (EXCLUDED.last_touched_at - t.last_touched_at)) * :leak_rate)
+          )
+        )
+      RETURNING
+        level,
+        -- Compare level to the capacity inside the DB so that we won't have rounding issues
+        level >= :capa AS did_overflow
+    SQL
+
+    # Note the use of .uncached here. The AR query cache will actually see our
+    # query as a repeat (since we use "select_one" for the RETURNING bit) and will not call into Postgres
+    # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
+    # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
+    upserted = conn.uncached { conn.select_one(sql) }
+    capped_level_after_fillup, did_overflow = upserted.fetch("level"), upserted.fetch("did_overflow")
+    [capped_level_after_fillup, did_overflow]
+  end
+
+  def set_block(conn:, key:, block_for:)
+    query_params = {key: key.to_s, block_for: block_for.to_f}
+    block_set_query = Sanitizer.new(conn).sanitize_sql_array([<<~SQL, query_params])
+      INSERT INTO pecorino_blocks AS t
+        (key, blocked_until)
+      VALUES
+        (:key, NOW() + ':block_for seconds'::interval)
+      ON CONFLICT (key) DO UPDATE SET
+        blocked_until = GREATEST(EXCLUDED.blocked_until, t.blocked_until)
+      RETURNING blocked_until;
+    SQL
+    conn.uncached { conn.select_value(block_set_query) }
+  end
+
+  private
+
+  def sanitize_sql_array_via_connection(connection, ...)
+    # TODO: terrible hack
+    sanitizer = begin
+      struct_class = Struct.new(:connection)
+      struct_class.send(:include, ActiveRecord::Sanitization::ClassMethods)
+      struct_class.new(connection)
+    end
+    sanitizer.sanitize_sql_array(...)
+  end
+
+  extend self
+end

--- a/lib/pecorino/sqlite.rb
+++ b/lib/pecorino/sqlite.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Pecorino::Sqlite < Struct.new(:model_class)
+Pecorino::Sqlite = Struct.new(:model_class) do
   def state(key:, capa:, leak_rate:)
     # With a server database, it is really important to use the clock of the database itself so
     # that concurrent requests will see consistent bucket level calculations. Since SQLite is

--- a/lib/pecorino/sqlite.rb
+++ b/lib/pecorino/sqlite.rb
@@ -110,7 +110,6 @@ class Pecorino::Sqlite < Struct.new(:model_class)
   end
 
   def blocked_until(key:)
-    # This query is database-agnostic, so it is not in the various database modules
     now_s = Time.now.to_f
     block_check_query = model_class.sanitize_sql_array([<<~SQL, {now_s: now_s, key: key}])
       SELECT

--- a/lib/pecorino/sqlite.rb
+++ b/lib/pecorino/sqlite.rb
@@ -114,8 +114,10 @@ class Pecorino::Sqlite < Struct.new(:model_class)
     block_check_query = model_class.sanitize_sql_array([<<~SQL, {key: key}])
       SELECT
         blocked_until
-      FROM pecorino_blocks
-      WHERE key = :key AND blocked_until >= DATETIME('now') LIMIT 1
+      FROM
+        pecorino_blocks
+      WHERE
+        key = :key AND blocked_until >= DATETIME('now') LIMIT 1
     SQL
     model_class.connection.uncached { model_class.connection.select_value(block_check_query) }
   end

--- a/lib/pecorino/throttle.rb
+++ b/lib/pecorino/throttle.rb
@@ -106,24 +106,14 @@ class Pecorino::Throttle
     return State.new(nil) unless @bucket.fillup(n.to_f).full?
 
     # and set the block if we reached it
-    query_params = {key: @key, block_for: @block_for}
-    block_set_query = ActiveRecord::Base.sanitize_sql_array([<<~SQL, query_params])
-      INSERT INTO pecorino_blocks AS t
-        (key, blocked_until)
-      VALUES
-        (:key, NOW() + ':block_for seconds'::interval)
-      ON CONFLICT (key) DO UPDATE SET
-        blocked_until = GREATEST(EXCLUDED.blocked_until, t.blocked_until)
-      RETURNING blocked_until;
-    SQL
-
-    fresh_blocked_until = conn.uncached { conn.select_value(block_set_query) }
+    fresh_blocked_until = Pecorino::Postgres.set_block(conn: conn, key: @key, block_for: @block_for)
     State.new(fresh_blocked_until.utc)
   end
 
   private
 
   def blocked_until(via_connection)
+    # This query is database-agnostic, so it is not in the various database modules
     block_check_query = ActiveRecord::Base.sanitize_sql_array([<<~SQL, @key])
       SELECT blocked_until FROM pecorino_blocks WHERE key = ? AND blocked_until >= NOW() LIMIT 1
     SQL

--- a/pecorino.gemspec
+++ b/pecorino.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "activerecord", "~> 7"
   spec.add_development_dependency "pg"
+  spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "activesupport", "~> 7.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -3,24 +3,12 @@
 require "test_helper"
 
 class LeakyBucketPostgresTest < ActiveSupport::TestCase
-  setup do
-    seed_db_name = Random.new(Minitest.seed).hex(4)
-    ActiveRecord::Migration.verbose = false
-    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
-    ActiveRecord::Base.connection.create_database("pecorino_tests_%s" % seed_db_name, charset: :unicode)
-    ActiveRecord::Base.connection.close
-    ActiveRecord::Base.establish_connection(adapter: "postgresql", encoding: "unicode", database: "pecorino_tests_%s" % seed_db_name)
-
-    ActiveRecord::Schema.define(version: 1) do |via_definer|
-      Pecorino.create_tables(via_definer)
-    end
+  def setup
+    create_postgres_database
   end
 
-  teardown do
-    seed_db_name = Random.new(Minitest.seed).hex(4)
-    ActiveRecord::Base.connection.close
-    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
-    ActiveRecord::Base.connection.drop_database("pecorino_tests_%s" % seed_db_name)
+  def teardown
+    drop_postgres_database
   end
 
   # This test is performed multiple times since time is involved, and there can be fluctuations

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LeakyBucketPostgresTest < ActiveSupport::TestCase
+  setup do
+    seed_db_name = Random.new(Minitest.seed).hex(4)
+    ActiveRecord::Migration.verbose = false
+    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
+    ActiveRecord::Base.connection.create_database("pecorino_tests_%s" % seed_db_name, charset: :unicode)
+    ActiveRecord::Base.connection.close
+    ActiveRecord::Base.establish_connection(adapter: "postgresql", encoding: "unicode", database: "pecorino_tests_%s" % seed_db_name)
+
+    ActiveRecord::Schema.define(version: 1) do |via_definer|
+      Pecorino.create_tables(via_definer)
+    end
+  end
+
+  teardown do
+    seed_db_name = Random.new(Minitest.seed).hex(4)
+    ActiveRecord::Base.connection.close
+    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
+    ActiveRecord::Base.connection.drop_database("pecorino_tests_%s" % seed_db_name)
+  end
+
+  # This test is performed multiple times since time is involved, and there can be fluctuations
+  # between the iterations
+  8.times do |n|
+    test "on iteration #{n} accepts a certain number of tokens and returns the new bucket level" do
+      bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 1.1, capacity: 15)
+      assert_in_delta bucket.state.level, 0, 0.0001
+
+      state = bucket.fillup(20)
+      assert_predicate state, :full?
+      assert_in_delta state.level, 15.0, 0.0001
+
+      sleep 0.2
+      assert_in_delta bucket.state.level, 14.77, 0.1
+
+      sleep 0.3
+      assert_in_delta bucket.state.level, 14.4, 0.1
+      assert_in_delta bucket.fillup(-3).level, 11.4, 0.1
+
+      assert_in_delta bucket.fillup(-300).level, 0, 0.1
+    end
+  end
+
+  test "does not allow a bucket to be created with a negative value" do
+    bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 1.1, capacity: 15)
+    assert_in_delta bucket.state.level, 0, 0.0001
+
+    state = bucket.fillup(-10)
+    assert_in_delta state.level, 0, 0.1
+  end
+
+  test "allows check for the bucket leaking out" do
+    bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 1.1, capacity: 15)
+    assert_in_delta bucket.state.level, 0, 0.0001
+
+    state = bucket.fillup(10)
+    refute_predicate state, :full?
+
+    refute bucket.able_to_accept?(6)
+    assert bucket.able_to_accept?(4)
+    assert_in_delta bucket.state.level, 10.0, 0.1
+  end
+
+  test "allows the bucket to leak out completely" do
+    bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 2, capacity: 1)
+    assert_predicate bucket.fillup(1), :full?
+
+    sleep(0.25)
+    assert_in_delta bucket.state.level, 0.5, 0.1
+
+    sleep(0.25)
+    assert_in_delta bucket.state.level, 0, 0.1
+  end
+end

--- a/test/leaky_bucket_sqlite_test.rb
+++ b/test/leaky_bucket_sqlite_test.rb
@@ -2,75 +2,12 @@
 
 require "test_helper"
 
-class LeakyBucketSqliteTest < ActiveSupport::TestCase
-  setup do
-    ActiveRecord::Migration.verbose = false
-    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: test_db_filename)
-
-    ActiveRecord::Schema.define(version: 1) do |via_definer|
-      Pecorino.create_tables(via_definer)
-    end
+class LeakyBucketSqliteTest < LeakyBucketPostgresTest
+  def setup
+    setup_sqlite_db
   end
 
-  teardown do
-    ActiveRecord::Base.connection.close
-    FileUtils.rm_rf(test_db_filename)
-  end
-
-  def test_db_filename
-    "pecorino_tests_%s.sqlite3" % Random.new(Minitest.seed).hex(4)
-  end
-
-  # This test is performed multiple times since time is involved, and there can be fluctuations
-  # between the iterations
-  8.times do |n|
-    test "on iteration #{n} accepts a certain number of tokens and returns the new bucket level" do
-      bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 1.1, capacity: 15)
-      assert_in_delta bucket.state.level, 0, 0.0001
-
-      state = bucket.fillup(20)
-      assert_predicate state, :full?
-      assert_in_delta state.level, 15.0, 0.0001
-
-      sleep 0.2
-      assert_in_delta bucket.state.level, 14.77, 0.1
-
-      sleep 0.3
-      assert_in_delta bucket.state.level, 14.4, 0.1
-      assert_in_delta bucket.fillup(-3).level, 11.4, 0.1
-
-      assert_in_delta bucket.fillup(-300).level, 0, 0.1
-    end
-  end
-
-  test "does not allow a bucket to be created with a negative value" do
-    bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 1.1, capacity: 15)
-    assert_in_delta bucket.state.level, 0, 0.0001
-
-    state = bucket.fillup(-10)
-    assert_in_delta state.level, 0, 0.1
-  end
-
-  test "allows check for the bucket leaking out" do
-    bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 1.1, capacity: 15)
-    assert_in_delta bucket.state.level, 0, 0.0001
-
-    state = bucket.fillup(10)
-    refute_predicate state, :full?
-
-    refute bucket.able_to_accept?(6)
-    assert bucket.able_to_accept?(4)
-    assert_in_delta bucket.state.level, 10.0, 0.1
-  end
-
-  test "allows the bucket to leak out completely" do
-    bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 2, capacity: 1)
-    assert_predicate bucket.fillup(1), :full?
-
-    sleep(0.25)
-    assert_in_delta bucket.state.level, 0.5, 0.1
-
-    sleep(0.25)
-    assert_in_delta bucket.state.level, 0, 0.1
+  def teardown
+    drop_sqlite_db
   end
 end

--- a/test/leaky_bucket_sqlite_test.rb
+++ b/test/leaky_bucket_sqlite_test.rb
@@ -2,14 +2,10 @@
 
 require "test_helper"
 
-class LeakyBucketTest < ActiveSupport::TestCase
+class LeakyBucketSqliteTest < ActiveSupport::TestCase
   setup do
-    seed_db_name = Random.new(Minitest.seed).hex(4)
     ActiveRecord::Migration.verbose = false
-    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
-    ActiveRecord::Base.connection.create_database("pecorino_tests_%s" % seed_db_name, charset: :unicode)
-    ActiveRecord::Base.connection.close
-    ActiveRecord::Base.establish_connection(adapter: "postgresql", encoding: "unicode", database: "pecorino_tests_%s" % seed_db_name)
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: test_db_filename)
 
     ActiveRecord::Schema.define(version: 1) do |via_definer|
       Pecorino.create_tables(via_definer)
@@ -17,10 +13,12 @@ class LeakyBucketTest < ActiveSupport::TestCase
   end
 
   teardown do
-    seed_db_name = Random.new(Minitest.seed).hex(4)
     ActiveRecord::Base.connection.close
-    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
-    ActiveRecord::Base.connection.drop_database("pecorino_tests_%s" % seed_db_name)
+    FileUtils.rm_rf(test_db_filename)
+  end
+
+  def test_db_filename
+    "pecorino_tests_%s.sqlite3" % Random.new(Minitest.seed).hex(4)
   end
 
   # This test is performed multiple times since time is involved, and there can be fluctuations

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,3 +7,43 @@ require "minitest/autorun"
 require "active_support"
 require "active_support/test_case"
 require "active_record"
+
+class ActiveSupport::TestCase
+  def setup_sqlite_db
+    ActiveRecord::Migration.verbose = false
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: test_db_filename)
+
+    ActiveRecord::Schema.define(version: 1) do |via_definer|
+      Pecorino.create_tables(via_definer)
+    end
+  end
+
+  def drop_sqlite_db
+    ActiveRecord::Base.connection.close
+    FileUtils.rm_rf(test_db_filename)
+  end
+
+  def test_db_filename
+    "pecorino_tests_%s.sqlite3" % Random.new(Minitest.seed).hex(4)
+  end
+
+  def create_postgres_database
+    seed_db_name = Random.new(Minitest.seed).hex(4)
+    ActiveRecord::Migration.verbose = false
+    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
+    ActiveRecord::Base.connection.create_database("pecorino_tests_%s" % seed_db_name, charset: :unicode)
+    ActiveRecord::Base.connection.close
+    ActiveRecord::Base.establish_connection(adapter: "postgresql", encoding: "unicode", database: "pecorino_tests_%s" % seed_db_name)
+
+    ActiveRecord::Schema.define(version: 1) do |via_definer|
+      Pecorino.create_tables(via_definer)
+    end
+  end
+
+  def drop_postgres_database
+    seed_db_name = Random.new(Minitest.seed).hex(4)
+    ActiveRecord::Base.connection.close
+    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
+    ActiveRecord::Base.connection.drop_database("pecorino_tests_%s" % seed_db_name)
+  end
+end

--- a/test/throttle_postgres_test.rb
+++ b/test/throttle_postgres_test.rb
@@ -10,24 +10,12 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
     end.pack("C*")
   end
 
-  setup do
-    seed_db_name = Random.new(Minitest.seed).hex(4)
-    ActiveRecord::Migration.verbose = false
-    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
-    ActiveRecord::Base.connection.create_database("pecorino_tests_%s" % seed_db_name, charset: :unicode)
-    ActiveRecord::Base.connection.close
-    ActiveRecord::Base.establish_connection(adapter: "postgresql", encoding: "unicode", database: "pecorino_tests_%s" % seed_db_name)
-
-    ActiveRecord::Schema.define(version: 1) do |via_definer|
-      Pecorino.create_tables(via_definer)
-    end
+  def setup
+    create_postgres_database
   end
 
-  teardown do
-    seed_db_name = Random.new(Minitest.seed).hex(4)
-    ActiveRecord::Base.connection.close
-    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
-    ActiveRecord::Base.connection.drop_database("pecorino_tests_%s" % seed_db_name)
+  def teardown
+    drop_postgres_database
   end
 
   test "throttles using request!() and blocks" do

--- a/test/throttle_postgres_test.rb
+++ b/test/throttle_postgres_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ThrottlePostgresTest < ActiveSupport::TestCase
+  def random_leaky_bucket_name(random: Random.new)
+    (1..32).map do
+      # bytes 97 to 122 are printable lowercase a-z
+      random.rand(97..122)
+    end.pack("C*")
+  end
+
+  setup do
+    seed_db_name = Random.new(Minitest.seed).hex(4)
+    ActiveRecord::Migration.verbose = false
+    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
+    ActiveRecord::Base.connection.create_database("pecorino_tests_%s" % seed_db_name, charset: :unicode)
+    ActiveRecord::Base.connection.close
+    ActiveRecord::Base.establish_connection(adapter: "postgresql", encoding: "unicode", database: "pecorino_tests_%s" % seed_db_name)
+
+    ActiveRecord::Schema.define(version: 1) do |via_definer|
+      Pecorino.create_tables(via_definer)
+    end
+  end
+
+  teardown do
+    seed_db_name = Random.new(Minitest.seed).hex(4)
+    ActiveRecord::Base.connection.close
+    ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "postgres")
+    ActiveRecord::Base.connection.drop_database("pecorino_tests_%s" % seed_db_name)
+  end
+
+  test "throttles using request!() and blocks" do
+    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 3)
+
+    29.times do
+      throttle.request!
+    end
+
+    # Depending on timing either the 31st or the 30th request may start to throttle
+    err = assert_raises Pecorino::Throttle::Throttled do
+      loop { throttle.request! }
+    end
+
+    assert_in_delta err.retry_after, 3, 0.5
+    sleep 0.5
+
+    # Ensure we are still throttled
+    err = assert_raises Pecorino::Throttle::Throttled do
+      throttle.request!
+    end
+    assert_equal throttle, err.throttle
+    assert_in_delta err.retry_after, 2.5, 0.5
+
+    sleep(3.05)
+    assert_nothing_raised do
+      throttle.request!
+    end
+  end
+
+  test "still throttles using request() without raising exceptions" do
+    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 3)
+
+    20.times do
+      state = throttle.request
+      refute_predicate state, :blocked?
+    end
+
+    20.times do
+      throttle.request
+    end
+
+    state = throttle.request
+    assert_predicate state, :blocked?
+
+    assert_in_delta state.retry_after, 3, 0.5
+    sleep 0.5
+
+    # Ensure we are still throttled
+    state = throttle.request
+    assert_predicate state, :blocked?
+    assert_in_delta state.retry_after, 2.5, 0.5
+    assert_kind_of Time, state.blocked_until
+
+    sleep(3.05)
+    state = throttle.request
+    refute_predicate state, :blocked?
+  end
+
+  test "able_to_accept? returns the prediction whether the throttle will accept" do
+    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 2)
+
+    assert throttle.able_to_accept?
+    assert throttle.able_to_accept?(29)
+    refute throttle.able_to_accept?(31)
+
+    # Depending on timing either the 30th or the 31st request may start to throttle
+    assert_raises Pecorino::Throttle::Throttled do
+      loop { throttle.request! }
+    end
+    refute throttle.able_to_accept?
+
+    sleep 2.5
+    assert throttle.able_to_accept?
+  end
+
+  test "starts to throttle sooner with a higher fillup rate" do
+    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 3)
+
+    15.times do
+      throttle.request!(2)
+    end
+
+    # Depending on timing either the 31st or the 30th request may start to throttle
+    err = assert_raises Pecorino::Throttle::Throttled do
+      loop { throttle.request! }
+    end
+
+    assert_in_delta err.retry_after, 3, 0.5
+  end
+end

--- a/test/throttle_sqlite_test.rb
+++ b/test/throttle_sqlite_test.rb
@@ -2,118 +2,12 @@
 
 require "test_helper"
 
-class ThrottleSqliteTest < ActiveSupport::TestCase
-  def random_leaky_bucket_name(random: Random.new)
-    (1..32).map do
-      # bytes 97 to 122 are printable lowercase a-z
-      random.rand(97..122)
-    end.pack("C*")
+class ThrottleSqliteTest < ThrottlePostgresTest
+  def setup
+    setup_sqlite_db
   end
 
-  setup do
-    ActiveRecord::Migration.verbose = false
-    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: test_db_filename)
-
-    ActiveRecord::Schema.define(version: 1) do |via_definer|
-      Pecorino.create_tables(via_definer)
-    end
-  end
-
-  teardown do
-    ActiveRecord::Base.connection.close
-    FileUtils.rm_rf(test_db_filename)
-  end
-
-  def test_db_filename
-    "pecorino_tests_%s.sqlite3" % Random.new(Minitest.seed).hex(4)
-  end
-
-  test "throttles using request!() and blocks" do
-    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 3)
-
-    29.times do
-      throttle.request!
-    end
-
-    # Depending on timing either the 31st or the 30th request may start to throttle
-    err = assert_raises Pecorino::Throttle::Throttled do
-      loop { throttle.request! }
-    end
-
-    assert_in_delta err.retry_after, 3, 0.5
-    sleep 0.5
-
-    # Ensure we are still throttled
-    err = assert_raises Pecorino::Throttle::Throttled do
-      throttle.request!
-    end
-    assert_equal throttle, err.throttle
-    assert_in_delta err.retry_after, 2.5, 0.5
-
-    sleep(3.05)
-    assert_nothing_raised do
-      throttle.request!
-    end
-  end
-
-  test "still throttles using request() without raising exceptions" do
-    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 3)
-
-    20.times do
-      state = throttle.request
-      refute_predicate state, :blocked?
-    end
-
-    20.times do
-      throttle.request
-    end
-
-    state = throttle.request
-    assert_predicate state, :blocked?
-
-    assert_in_delta state.retry_after, 3, 0.5
-    sleep 0.5
-
-    # Ensure we are still throttled
-    state = throttle.request
-    assert_predicate state, :blocked?
-    assert_in_delta state.retry_after, 2.5, 0.5
-    assert_kind_of Time, state.blocked_until
-
-    sleep(3.05)
-    state = throttle.request
-    refute_predicate state, :blocked?
-  end
-
-  test "able_to_accept? returns the prediction whether the throttle will accept" do
-    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 2)
-
-    assert throttle.able_to_accept?
-    assert throttle.able_to_accept?(29)
-    refute throttle.able_to_accept?(31)
-
-    # Depending on timing either the 30th or the 31st request may start to throttle
-    assert_raises Pecorino::Throttle::Throttled do
-      loop { throttle.request! }
-    end
-    refute throttle.able_to_accept?
-
-    sleep 2.5
-    assert throttle.able_to_accept?
-  end
-
-  test "starts to throttle sooner with a higher fillup rate" do
-    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 3)
-
-    15.times do
-      throttle.request!(2)
-    end
-
-    # Depending on timing either the 31st or the 30th request may start to throttle
-    err = assert_raises Pecorino::Throttle::Throttled do
-      loop { throttle.request! }
-    end
-
-    assert_in_delta err.retry_after, 3, 0.5
+  def teardown
+    drop_sqlite_db
   end
 end


### PR DESCRIPTION
Allow Pecorino throttles and leaky buckets to be defined using SQLite. Note that it is not the SQLite "time" value that we use, but the Ruby value - it has a finer resolution and is easier to work with, and should be harmless since SQLite is in-process anyway.

The same could potentially be done with SQLite date and time functions, but I found them very hard to work with for getting time intervals - and the best resolution I could obtain was milliseconds, whereas Pecorino benefits from time resolution being finer than that.

The change moves the DB statements used into separate modules, one per DB. Since we only got 2 now I opted for inheritance in tests - to avoid duplication. Once we get a third one in we might switch to using a module.

Closes #4 