### PR TITLE
Allow over_time and set better block_for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Allow `over_time` in addition to `leak_rate`, which is a more intuitive parameter to tweak
+- Set default `block_for` to the time it takes the bucket to leak out completely instead of 30 seconds
+
 ## [0.2.0] - 2024-01-09
 
 - [Add support for SQLite](https://github.com/cheddar-me/pecorino/pull/9)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ And then execute:
 Once the installation is done you can use Pecorino to start defining your throttles. Imagine you have a resource called `vault` and you want to limit the number of updates to it to 5 per second. To achieve that, instantiate a new `Throttle` in your controller or job code, and then trigger it using `Throttle#request!`. A call to `request!` registers 1 token getting added to the bucket. If the bucket is full, or the throttle is currently in "block" mode (has recently been triggered), a `Pecorino::Throttle::Throttled` exception will be raised.
 
 ```ruby
-throttle = Pecorino::Throttle.new(key: "vault", over_time: 1, capacity: 5)
+throttle = Pecorino::Throttle.new(key: "vault", over_time: 1.second, capacity: 5)
 throttle.request!
 ```
 In a Rails controller you can then rescue from this exception to render the appropriate response:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ return render :capacity_exceeded unless throttle.able_to_accept?
 If you are dealing with a metered resource (like throughput, money, amount of storage...) you can supply the number of tokens to either `request!` or `able_to_accept?` to indicate the desired top-up of the leaky bucket. For example, if you are maintaining user wallets and want to ensure no more than 100 dollars may be taken from the wallet within a certain amount of time, you can do it like so:
 
 ```ruby
-throttle = Pecorino::Throttle.new(key: "wallet_t_#{current_user.id}", leak_rate: 100 / 60.0 / 60.0, capacity: 100, block_for: 60*60*3)
+throttle = Pecorino::Throttle.new(key: "wallet_t_#{current_user.id}", over_time_: 1.hour, capacity: 100, block_for: 60*60*3)
 throttle.request!(20) # Attempt to withdraw 20 dollars
 throttle.request!(20) # Attempt to withdraw 20 dollars more
 throttle.request!(20) # Attempt to withdraw 20 dollars more

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ And then execute:
 Once the installation is done you can use Pecorino to start defining your throttles. Imagine you have a resource called `vault` and you want to limit the number of updates to it to 5 per second. To achieve that, instantiate a new `Throttle` in your controller or job code, and then trigger it using `Throttle#request!`. A call to `request!` registers 1 token getting added to the bucket. If the bucket is full, or the throttle is currently in "block" mode (has recently been triggered), a `Pecorino::Throttle::Throttled` exception will be raised.
 
 ```ruby
-throttle = Pecorino::Throttle.new(key: "vault", leak_rate: 5, capacity: 5)
+throttle = Pecorino::Throttle.new(key: "vault", over_time: 1, capacity: 5)
 throttle.request!
 ```
 In a Rails controller you can then rescue from this exception to render the appropriate response:

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -77,9 +77,12 @@ class Pecorino::LeakyBucket
   # @param key[String] the key for the bucket. The key also gets used
   #   to derive locking keys, so that operations on a particular bucket
   #   are always serialized.
-  # @param leak_rate[Float] the leak rate of the bucket, in tokens per second
-  # @param over_time[Float] over how long the bucket will leak out.
-  #   Either of `leak_rate` or `over_time` can be used
+  # @param leak_rate[Float] the leak rate of the bucket, in tokens per second.
+  #   Either `leak_rate` or `over_time` can be used, but not both. 
+  # @param over_time[#to_f] over how many seconds the bucket will leak out to 0 tokens.
+  #   The value is assumed to be the number of seconds
+  #   - or a duration which returns the number of seconds from `to_f`.
+  #   Either `leak_rate` or `over_time` can be used, but not both. 
   # @param capacity[Numeric] how many tokens is the bucket capped at.
   #   Filling up the bucket using `fillup()` will add to that number, but
   #   the bucket contents will then be capped at this value. So with

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -78,11 +78,11 @@ class Pecorino::LeakyBucket
   #   to derive locking keys, so that operations on a particular bucket
   #   are always serialized.
   # @param leak_rate[Float] the leak rate of the bucket, in tokens per second.
-  #   Either `leak_rate` or `over_time` can be used, but not both. 
+  #   Either `leak_rate` or `over_time` can be used, but not both.
   # @param over_time[#to_f] over how many seconds the bucket will leak out to 0 tokens.
   #   The value is assumed to be the number of seconds
   #   - or a duration which returns the number of seconds from `to_f`.
-  #   Either `leak_rate` or `over_time` can be used, but not both. 
+  #   Either `leak_rate` or `over_time` can be used, but not both.
   # @param capacity[Numeric] how many tokens is the bucket capped at.
   #   Filling up the bucket using `fillup()` will add to that number, but
   #   the bucket contents will then be capped at this value. So with

--- a/lib/pecorino/throttle.rb
+++ b/lib/pecorino/throttle.rb
@@ -43,13 +43,14 @@ class Pecorino::Throttle
   end
 
   # @param key[String] the key for both the block record and the leaky bucket
-  # @param block_for[Numeric] the number of seconds to block any further requests for
+  # @param block_for[Numeric] the number of seconds to block any further requests for. Defaults to time it takes
+  #   the bucket to leak out to the level of 0
   # @param leaky_bucket_options Options for `Pecorino::LeakyBucket.new`
   # @see PecorinoLeakyBucket.new
-  def initialize(key:, block_for: 30, **)
-    @key = key.to_s
-    @block_for = block_for.to_f
+  def initialize(key:, block_for: nil, **)
     @bucket = Pecorino::LeakyBucket.new(key:, **)
+    @key = key.to_s
+    @block_for = block_for ? block_for.to_f : (@bucket.capacity / @bucket.leak_rate)
   end
 
   # Tells whether the throttle will let this number of requests pass without raising

--- a/test/throttle_postgres_test.rb
+++ b/test/throttle_postgres_test.rb
@@ -46,6 +46,12 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
     end
   end
 
+  test "allows the block_for parameter to be omitted" do
+    assert_nothing_raised do
+      Pecorino::Throttle.new(key: random_leaky_bucket_name, over_time: 1, capacity: 30)
+    end
+  end
+
   test "still throttles using request() without raising exceptions" do
     throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 3)
 


### PR DESCRIPTION
over_time is easier to wrap your head around than leak_rate. A standard block_for should probably be corresponding to the bucket leak rate and not be set to an arbitrary value