### PR TITLE
Allow conditional fillup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Make sure Bucket#able_to_accept? allows the bucket to be filled to capacity, not only to below capacity
 - Improve YARD documentation
 - Allow "conditional fillup" - only add tokens to the leaky bucket if the bucket has enough space
 - Fix `over_time` leading to incorrect `leak_rate`. The divider/divisor were swapped, leading to the inverse leak rate getting computed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- Improve YARD documentation
+- Allow "conditional fillup" - only add tokens to the leaky bucket if the bucket has enough space
+- Fix `over_time` leading to incorrect `leak_rate`. The divider/divisor were swapped, leading to the inverse leak rate getting computed.
+
 ## [0.3.0] - 2024-01-18
 
 - Allow `over_time` in addition to `leak_rate`, which is a more intuitive parameter to tweak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 - Make sure Bucket#able_to_accept? allows the bucket to be filled to capacity, not only to below capacity
 - Improve YARD documentation
-- Allow "conditional fillup" - only add tokens to the leaky bucket if the bucket has enough space
+- Allow "conditional fillup" - only add tokens to the leaky bucket if the bucket has enough space.
 - Fix `over_time` leading to incorrect `leak_rate`. The divider/divisor were swapped, leading to the inverse leak rate getting computed.
 
 ## [0.3.0] - 2024-01-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- Use Bucket#connditional_fillup inside Throttle and throttle only when the capacity _would_ be exceeded, as opposed
+  to throttling when capacity has already been exceeded. This allows for finer-grained throttles such as
+  "at most once in", where filling "exactly to capacity" is a requirement. It also provides for more accurate
+  and easier to understand throttling in general.
 - Make sure Bucket#able_to_accept? allows the bucket to be filled to capacity, not only to below capacity
 - Improve YARD documentation
 - Allow "conditional fillup" - only add tokens to the leaky bucket if the bucket has enough space.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ And then execute:
 
 ## Usage
 
-Once the installation is done you can use Pecorino to start defining your throttles. Imagine you have a resource called `vault` and you want to limit the number of updates to it to 5 per second. To achieve that, instantiate a new `Throttle` in your controller or job code, and then trigger it using `Throttle#request!`. A call to `request!` registers 1 token getting added to the bucket. If the bucket is full, or the throttle is currently in "block" mode (has recently been triggered), a `Pecorino::Throttle::Throttled` exception will be raised.
+Once the installation is done you can use Pecorino to start defining your throttles. Imagine you have a resource called `vault` and you want to limit the number of updates to it to 5 per second. To achieve that, instantiate a new `Throttle` in your controller or job code, and then trigger it using `Throttle#request!`. A call to `request!` registers 1 token getting added to the bucket. If the bucket would overspill (your request would make it overflow), or the throttle is currently in "block" mode (has recently been triggered), a `Pecorino::Throttle::Throttled` exception will be raised.
 
 ```ruby
 throttle = Pecorino::Throttle.new(key: "vault", over_time: 1.second, capacity: 5)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ throttle.request!(20) # Attempt to withdraw 20 dollars more
 throttle.request!(2) # Attempt to withdraw 2 dollars more, will raise `Throttled` and block withdrawals for 3 hours
 ```
 
+## Using just the leaky bucket
+
 Sometimes you don't want to use a throttle, but you want to track the amount added to the leaky bucket over time. A lower-level abstraction is available for that purpose in the form of the `LeakyBucket` class. It will not raise any exceptions and will not install blocks, but will permit you to track a bucket's state over time:
 
 
@@ -77,7 +79,8 @@ sleep 0.2
 b.state #=> Pecorino::LeakyBucket::State(full?: false, level: 1.8)
 ```
 
-Check out the inline YARD documentation for more options.
+Check out the inline YARD documentation for more options. Do take note of the differences between `fillup()` and `fillup_conditionally` as you
+might want to pick one or the other depending on your use case.
 
 ## Cleaning out stale locks from the database
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ return render :capacity_exceeded unless throttle.able_to_accept?
 If you are dealing with a metered resource (like throughput, money, amount of storage...) you can supply the number of tokens to either `request!` or `able_to_accept?` to indicate the desired top-up of the leaky bucket. For example, if you are maintaining user wallets and want to ensure no more than 100 dollars may be taken from the wallet within a certain amount of time, you can do it like so:
 
 ```ruby
-throttle = Pecorino::Throttle.new(key: "wallet_t_#{current_user.id}", over_time_: 1.hour, capacity: 100, block_for: 60*60*3)
+throttle = Pecorino::Throttle.new(key: "wallet_t_#{current_user.id}", over_time_: 1.hour, capacity: 100, block_for: 3.hours)
 throttle.request!(20) # Attempt to withdraw 20 dollars
 throttle.request!(20) # Attempt to withdraw 20 dollars more
 throttle.request!(20) # Attempt to withdraw 20 dollars more
@@ -82,7 +82,7 @@ b.state #=> Pecorino::LeakyBucket::State(full?: false, level: 1.8)
 Check out the inline YARD documentation for more options. Do take note of the differences between `fillup()` and `fillup_conditionally` as you
 might want to pick one or the other depending on your use case.
 
-## Cleaning out stale locks from the database
+## Cleaning out stale buckets and blocks from the database
 
 We recommend running the following bit of code every couple of hours (via cron or similar) to delete the stale blocks and leaky buckets from the system:
 

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -129,7 +129,7 @@ class Pecorino::LeakyBucket
   #
   # @param n_tokens[Float]
   # @return [ConditionalFillupResult] the state of the bucket after the operation and whether the operation succeeded
-  def fillup_if_able(n_tokens)
+  def fillup_conditionally(n_tokens)
     capped_level_after_fillup, is_full, did_accept = Pecorino.adapter.add_tokens_conditionally(capacity: @capacity, key: @key, leak_rate: @leak_rate, n_tokens: n_tokens)
     ConditionalFillupResult.new(capped_level_after_fillup, is_full, did_accept)
   end

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -156,6 +156,6 @@ class Pecorino::LeakyBucket
   # @param n_tokens[Float]
   # @return [boolean]
   def able_to_accept?(n_tokens)
-    (state.level + n_tokens) < @capacity
+    (state.level + n_tokens) <= @capacity
   end
 end

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -96,7 +96,7 @@ class Pecorino::LeakyBucket
   def initialize(key:, capacity:, leak_rate: nil, over_time: nil)
     raise ArgumentError, "Either leak_rate: or over_time: must be specified" if leak_rate.nil? && over_time.nil?
     raise ArgumentError, "Either leak_rate: or over_time: may be specified, but not both" if leak_rate && over_time
-    @leak_rate = leak_rate || (over_time.to_f / capacity)
+    @leak_rate = leak_rate || (capacity / over_time.to_f)
     @key = key
     @capacity = capacity.to_f
   end

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -102,7 +102,8 @@ class Pecorino::LeakyBucket
   end
 
   # Places `n` tokens in the bucket. If the bucket has less capacity than `n` tokens, the bucket will be filled to capacity.
-  # If the bucket has less capacity than `n` tokens, it will be filled to capacity.
+  # If the bucket has less capacity than `n` tokens, it will be filled to capacity. If the bucket is already full
+  # when the fillup is requested, the bucket stays at capacity.
   #
   # Once tokens are placed, the bucket is set to expire within 2 times the time it would take it to leak to 0,
   # regardless of how many tokens get put in - since the amount of tokens put in the bucket will always be capped
@@ -115,10 +116,9 @@ class Pecorino::LeakyBucket
     State.new(capped_level_after_fillup, is_full)
   end
 
-  # Places `n` tokens in the bucket, but only if there actually is enough capacity left.
-
   # Places `n` tokens in the bucket. If the bucket has less capacity than `n` tokens, the fillup will be rejected.
-  # This can be used for "exactly once" semantics or just more precise rate limiting.
+  # This can be used for "exactly once" semantics or just more precise rate limiting. Note that if the bucket has
+  # _exactly_ `n` tokens of capacity the fillup will be accepted.
   #
   # Once tokens are placed, the bucket is set to expire within 2 times the time it would take it to leak to 0,
   # regardless of how many tokens get put in - since the amount of tokens put in the bucket will always be capped

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -54,10 +54,7 @@ class Pecorino::LeakyBucket
       @accepted = !!accepted
     end
 
-    # Tells whether the bucket accepted the proposed fillup. If the fillup
-    # would fill the bucket to capacity, the bucket should have accepted the
-    # fillup. If the fullup would make the bucket overflow, the fillup gets
-    # rejected and the fillup does not take place.
+    # Tells whether the bucket did accept the requested fillup
     # @return [Boolean]
     def accepted?
       @accepted

--- a/lib/pecorino/leaky_bucket.rb
+++ b/lib/pecorino/leaky_bucket.rb
@@ -25,7 +25,6 @@
 # The storage use is one DB row per leaky bucket you need to manage (likely - one throttled entity such
 # as a combination of an IP address + the URL you need to procect). The `key` is an arbitrary string you provide.
 class Pecorino::LeakyBucket
-
   # Returned from `.state` and `.fillup`
   class State
     def initialize(level, is_full)
@@ -35,9 +34,7 @@ class Pecorino::LeakyBucket
 
     # Returns the level of the bucket
     # @return [Float]
-    def level
-      @level
-    end
+    attr_reader :level
 
     # Tells whether the bucket was detected to be full when the operation on
     # the LeakyBucket was performed.
@@ -133,7 +130,7 @@ class Pecorino::LeakyBucket
     capped_level_after_fillup, is_full, did_accept = Pecorino.adapter.add_tokens_conditionally(capacity: @capacity, key: @key, leak_rate: @leak_rate, n_tokens: n_tokens)
     ConditionalFillupResult.new(capped_level_after_fillup, is_full, did_accept)
   end
-  
+
   # Returns the current state of the bucket, containing the level and whether the bucket is full.
   # Calling this method will not perform any database writes.
   #

--- a/lib/pecorino/postgres.rb
+++ b/lib/pecorino/postgres.rb
@@ -84,6 +84,11 @@ Pecorino::Postgres = Struct.new(:model_class) do
     [capped_level_after_fillup, did_overflow]
   end
 
+  def add_tokens_conditionally(key:, capacity:, leak_rate:, n_tokens:)
+    capped_level, at_capacity = add_tokens(key:, capacity:, leak_rate:, n_tokens:)
+    [capped_level, at_capacity, _did_accept = true]
+  end
+
   def set_block(key:, block_for:)
     query_params = {key: key.to_s, block_for: block_for.to_f}
     block_set_query = model_class.sanitize_sql_array([<<~SQL, query_params])

--- a/lib/pecorino/postgres.rb
+++ b/lib/pecorino/postgres.rb
@@ -72,7 +72,7 @@ Pecorino::Postgres = Struct.new(:model_class) do
       RETURNING
         level,
         -- Compare level to the capacity inside the DB so that we won't have rounding issues
-        level >= :capacity AS did_overflow
+        level >= :capacity AS at_capacity
     SQL
 
     # Note the use of .uncached here. The AR query cache will actually see our
@@ -80,13 +80,68 @@ Pecorino::Postgres = Struct.new(:model_class) do
     # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
     # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
     upserted = model_class.connection.uncached { model_class.connection.select_one(sql) }
-    capped_level_after_fillup, did_overflow = upserted.fetch("level"), upserted.fetch("did_overflow")
-    [capped_level_after_fillup, did_overflow]
+    capped_level_after_fillup, at_capacity = upserted.fetch("level"), upserted.fetch("at_capacity")
+    [capped_level_after_fillup, at_capacity]
   end
 
   def add_tokens_conditionally(key:, capacity:, leak_rate:, n_tokens:)
-    capped_level, at_capacity = add_tokens(key:, capacity:, leak_rate:, n_tokens:)
-    [capped_level, at_capacity, _did_accept = true]
+    # Take double the time it takes the bucket to empty under normal circumstances
+    # until the bucket may be deleted.
+    may_be_deleted_after_seconds = (capacity.to_f / leak_rate.to_f) * 2.0
+
+    # Create the leaky bucket if it does not exist, and update
+    # to the new level, taking the leak rate into account - if the bucket exists.
+    query_params = {
+      key: key.to_s,
+      capacity: capacity.to_f,
+      delete_after_s: may_be_deleted_after_seconds,
+      leak_rate: leak_rate.to_f,
+      fillup: n_tokens.to_f
+    }
+
+    sql = model_class.sanitize_sql_array([<<~SQL, query_params])
+      WITH pre AS (
+        SELECT
+          GREATEST(0.0, LEAST(:capacity, level - (EXTRACT(EPOCH FROM (clock_timestamp() - last_touched_at)) * :leak_rate))) AS level_after_leaking
+        FROM pecorino_leaky_buckets
+        WHERE key = :key
+      )
+      INSERT INTO pecorino_leaky_buckets AS t
+        (key, last_touched_at, may_be_deleted_after, level)
+      VALUES
+        (
+          :key,
+          clock_timestamp(),
+          clock_timestamp() + ':delete_after_s second'::interval,
+          GREATEST(0.0,
+            LEAST(
+              :capacity,
+              :fillup
+            )
+          )
+        )
+      ON CONFLICT (key) DO UPDATE SET
+        last_touched_at = EXCLUDED.last_touched_at,
+        may_be_deleted_after = EXCLUDED.may_be_deleted_after,
+        level = CASE WHEN
+          ((SELECT level_after_leaking FROM pre) + :fillup) > :capacity THEN (SELECT level_after_leaking FROM pre)
+        ELSE
+          GREATEST(0.0, LEAST(:capacity, (SELECT level_after_leaking FROM pre) + :fillup))
+        END
+      RETURNING
+        level,
+        -- Compare level to the capacity inside the DB so that we won't have rounding issues
+        level >= :capacity AS at_capacity,
+        level != GREATEST(0.0, (SELECT level_after_leaking FROM pre)) AS did_accept
+    SQL
+
+    # Note the use of .uncached here. The AR query cache will actually see our
+    # query as a repeat (since we use "select_one" for the RETURNING bit) and will not call into Postgres
+    # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
+    # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
+    upserted = model_class.connection.uncached { model_class.connection.select_one(sql) }
+    capped_level, at_capacity, did_accept = upserted.fetch("level"), upserted.fetch("at_capacity"), upserted.fetch("did_accept")
+    [capped_level, at_capacity, did_accept]
   end
 
   def set_block(key:, block_for:)

--- a/lib/pecorino/postgres.rb
+++ b/lib/pecorino/postgres.rb
@@ -133,7 +133,6 @@ Pecorino::Postgres = Struct.new(:model_class) do
 
     # Re .uncached - https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
     upserted = model_class.connection.uncached { model_class.connection.select_one(sql) }
-    warn upserted.inspect
 
     level_after = upserted.fetch("level_after")
     level_before = upserted.fetch("level_before")

--- a/lib/pecorino/sqlite.rb
+++ b/lib/pecorino/sqlite.rb
@@ -94,6 +94,65 @@ Pecorino::Sqlite = Struct.new(:model_class) do
     [capped_level_after_fillup, one_if_did_overflow == 1]
   end
 
+  def add_tokens_conditionally(key:, capacity:, leak_rate:, n_tokens:)
+    # Take double the time it takes the bucket to empty under normal circumstances
+    # until the bucket may be deleted.
+    may_be_deleted_after_seconds = (capacity.to_f / leak_rate.to_f) * 2.0
+
+    # Create the leaky bucket if it does not exist, and update
+    # to the new level, taking the leak rate into account - if the bucket exists.
+    query_params = {
+      key: key.to_s,
+      capacity: capacity.to_f,
+      delete_after_s: may_be_deleted_after_seconds,
+      leak_rate: leak_rate.to_f,
+      now_s: Time.now.to_f, # See above as to why we are using a time value passed in
+      fillup: n_tokens.to_f,
+      id: SecureRandom.uuid # SQLite3 does not autogenerate UUIDs
+    }
+
+    sql = model_class.sanitize_sql_array([<<~SQL, query_params])
+      -- With SQLite MATERIALIZED has to be used so that level_post is calculated before the UPDATE takes effect
+      WITH pre(level_post_with_uncapped_fillup, level_post) AS MATERIALIZED (
+        SELECT
+          MAX(0.0, level + :fillup - ((:now_s - last_touched_at) * :leak_rate)) AS level_post_with_uncapped_fillup,
+          MAX(0.0, level + 0.0 - ((:now_s - last_touched_at) * :leak_rate)) AS level_post
+        FROM
+          pecorino_leaky_buckets
+        WHERE key = :key
+      )
+      INSERT INTO pecorino_leaky_buckets AS t
+        (id, key, last_touched_at, may_be_deleted_after, level)
+      VALUES
+        (
+          :id,
+          :key,
+          :now_s, -- Precision loss must be avoided here as it is used for calculations
+          DATETIME('now', '+:delete_after_s seconds'), -- Precision loss is acceptable here
+          MAX(0.0,
+            (CASE WHEN :fillup > :capacity THEN 0.0 ELSE :fillup END)
+          )
+        )
+      ON CONFLICT (key) DO UPDATE SET
+        last_touched_at = EXCLUDED.last_touched_at,
+        may_be_deleted_after = EXCLUDED.may_be_deleted_after,
+        level = CASE WHEN (SELECT level_post_with_uncapped_fillup FROM pre) <= :capacity THEN
+          (SELECT level_post_with_uncapped_fillup FROM pre)
+        ELSE
+          (SELECT level_post FROM pre)
+        END
+      RETURNING
+        COALESCE((SELECT level_post FROM pre), 0.0) AS level_before,
+        level AS level_after
+    SQL
+
+    # Re .uncached - https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
+    upserted = model_class.connection.uncached { model_class.connection.select_one(sql) }
+    level_after = upserted.fetch("level_after")
+    level_before = upserted.fetch("level_before")
+    [level_after, level_after >= capacity, level_after != level_before]
+  end
+
   def set_block(key:, block_for:)
     query_params = {id: SecureRandom.uuid, key: key.to_s, block_for: block_for.to_f, now_s: Time.now.to_f}
     block_set_query = model_class.sanitize_sql_array([<<~SQL, query_params])

--- a/lib/pecorino/sqlite.rb
+++ b/lib/pecorino/sqlite.rb
@@ -125,7 +125,10 @@ Pecorino::Sqlite = Struct.new(:model_class) do
           DATETIME('now', '+:delete_after_s seconds'), -- Precision loss is acceptable here
           0.0
         )
-      ON CONFLICT (key) DO NOTHING
+      ON CONFLICT (key) DO UPDATE SET
+      -- Make sure we extend the lifetime of the row
+      -- so that it can't be deleted between our INSERT and our UPDATE
+        may_be_deleted_after = EXCLUDED.may_be_deleted_after
     SQL
     model_class.connection.execute(insert_sql)
 

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -106,6 +106,11 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
     assert bucket.fillup_conditionally(1.0).accepted?
   end
 
+  test "with conditional fillup, refuses a fillup that would overflow" do
+    bucket = Pecorino::LeakyBucket.new(key: Random.uuid, over_time: 1.0, capacity: 1.0)
+    refute bucket.fillup_conditionally(1.1).accepted?
+  end
+
   test "with conditional fillup, allows an existing bucket to be filled to capacity on the second call (INSERT vs. UPDATE)" do
     bucket = Pecorino::LeakyBucket.new(key: Random.uuid, over_time: 1.0, capacity: 1.0)
     bucket.fillup(0.0) # Ensure the bucket row gets created
@@ -152,13 +157,9 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
 
   test "allows conditional fillup even if the bucket leaks out to 0 between calls" do
     bucket = Pecorino::LeakyBucket.new(key: Random.uuid, over_time: 0.5, capacity: 30)
-    # Once we above 29, the last fillup should be rejected
-    until bucket.state.level > 29
-      fillup_result = bucket.fillup_conditionally(1)
-      assert fillup_result.accepted?
-    end
-    refute bucket.fillup_conditionally(1).accepted?, "The 31st fillup should be rejected"
-    sleep 0.6 # Spend enough time to allow the bucket to leak out
+    assert bucket.fillup_conditionally(29.6).accepted?
+    refute bucket.fillup_conditionally(1).accepted?
+    sleep 0.6 # Spend enough time to allow the bucket to leak out completely
     assert bucket.fillup_conditionally(1).accepted?, "Once the bucket has leaked out to 0 the fillup should be accepted again"
   end
 end

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -45,6 +45,11 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
     assert_in_delta 2.0, throttle.leak_rate, 0.01
   end
 
+  test "tells whether it is able to accept a value which will bring it to capacity" do
+    bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 1, capacity: 3)
+    assert bucket.able_to_accept?(3)
+  end
+
   test "allows either of leak_rate or over_time to be used" do
     bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 1.1, capacity: 15)
     bucket.fillup(20)

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -40,6 +40,11 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
     assert_equal bucket.capacity, 15.0
   end
 
+  test "translates over_time into an appropriate leak_rate at instantiation" do
+    throttle = Pecorino::LeakyBucket.new(key: Random.uuid, over_time: 10, capacity: 20)
+    assert_in_delta 2.0, throttle.leak_rate, 0.01
+  end
+
   test "allows either of leak_rate or over_time to be used" do
     bucket = Pecorino::LeakyBucket.new(key: Random.uuid, leak_rate: 1.1, capacity: 15)
     bucket.fillup(20)

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -102,15 +102,15 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
       assert_in_delta should_have_reached_level, state.level, 0.1
     }
 
-    try_fillup.(1.1, 0.0, false) # Oversized fillup must be refused outright
-    try_fillup.(0.3, 0.3, true)
-    try_fillup.(0.3, 0.6, true)
-    try_fillup.(0.3, 0.9, true)
-    try_fillup.(0.3, 0.9, false) # Would take the bucket to 1.2, so must be rejected
+    try_fillup.call(1.1, 0.0, false) # Oversized fillup must be refused outright
+    try_fillup.call(0.3, 0.3, true)
+    try_fillup.call(0.3, 0.6, true)
+    try_fillup.call(0.3, 0.9, true)
+    try_fillup.call(0.3, 0.9, false) # Would take the bucket to 1.2, so must be rejected
 
     sleep(0.2) # Leak out 0.2 tokens
 
-    try_fillup.(0.3, 1.0, true)
-    try_fillup.(-2, 0.0, true) # A negative fillup is permitted since it will never take the bucket above capacity
+    try_fillup.call(0.3, 1.0, true)
+    try_fillup.call(-2, 0.0, true) # A negative fillup is permitted since it will never take the bucket above capacity
   end
 end

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -152,8 +152,9 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
 
   test "allows conditional fillup even if the bucket leaks out to 0 between calls" do
     bucket = Pecorino::LeakyBucket.new(key: Random.uuid, over_time: 0.5, capacity: 30)
-    30.times do
-      st = bucket.fillup_conditionally(1).accepted?
+    30.times do |i|
+      st = bucket.fillup_conditionally(1)
+      assert st.accepted?, "The #{i} fillup should have been accepted"
       warn st.inspect
     end
     st = bucket.fillup_conditionally(1)

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -90,4 +90,21 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
     sleep(0.25)
     assert_in_delta bucket.state.level, 0, 0.1
   end
+
+  test "allows conditional fillup using fillup_if_able" do
+    bucket = Pecorino::LeakyBucket.new(key: Random.uuid, over_time: 0.2, capacity: 1.0)
+
+    state_after_first_fillup = bucket.fillup_if_able(0.6)
+    assert_in_delta state_after_first_fillup.level, 0.6, 0.01
+    assert_predicate state_after_first_fillup, :did_accept?
+
+    state_after_second_fillup = bucket.fillup_if_able(0.6)
+    assert_in_delta state_after_second_fillup.level, 0.6, 0.01
+    refute_predicate state_after_second_fillup, :did_accept?
+
+    sleep 0.15
+    state_after_third_fillup = bucket.fillup_if_able(0.6)
+    assert_in_delta state_after_third_fillup.level, 0.6, 0.01
+    assert_predicate state_after_third_fillup, :did_accept?
+  end
 end

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -95,16 +95,15 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
     bucket = Pecorino::LeakyBucket.new(key: Random.uuid, over_time: 0.2, capacity: 1.0)
 
     state_after_first_fillup = bucket.fillup_if_able(0.6)
-    assert_in_delta state_after_first_fillup.level, 0.6, 0.01
+    assert_in_delta state_after_first_fillup.level, 0.6, 0.1
     assert_predicate state_after_first_fillup, :did_accept?
 
-    state_after_second_fillup = bucket.fillup_if_able(0.6)
-    assert_in_delta state_after_second_fillup.level, 0.6, 0.01
-    refute_predicate state_after_second_fillup, :did_accept?
+    state_after_second_fillup = bucket.fillup_if_able(0.3)
+    assert_in_delta state_after_second_fillup.level, 0.9, 0.1
+    assert_predicate state_after_second_fillup, :did_accept?
 
-    sleep 0.15
-    state_after_third_fillup = bucket.fillup_if_able(0.6)
-    assert_in_delta state_after_third_fillup.level, 0.6, 0.01
-    assert_predicate state_after_third_fillup, :did_accept?
+    state_after_third_fillup = bucket.fillup_if_able(0.3) # Would take the bucket to 1.2, so must be refused
+    assert_in_delta state_after_third_fillup.level, 0.9, 0.1
+    refute_predicate state_after_third_fillup, :did_accept?
   end
 end

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -96,7 +96,7 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
     assert_in_delta bucket.state.level, 0, 0.1
   end
 
-  test "allows conditional fillup using fillup_conditionally" do
+  test "allows conditional fillup" do
     bucket = Pecorino::LeakyBucket.new(key: Random.uuid, over_time: 1.0, capacity: 1.0)
 
     counter = 0
@@ -117,5 +117,6 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
 
     try_fillup.call(0.3, 1.0, true)
     try_fillup.call(-2, 0.0, true) # A negative fillup is permitted since it will never take the bucket above capacity
+    try_fillup.call(1.0, 1.0, true) # Filling up in one step should be permitted
   end
 end

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -153,7 +153,8 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
   test "allows conditional fillup even if the bucket leaks out to 0 between calls" do
     bucket = Pecorino::LeakyBucket.new(key: Random.uuid, over_time: 0.5, capacity: 30)
     30.times do
-      assert bucket.fillup_conditionally(1).accepted?
+      st = bucket.fillup_conditionally(1).accepted?
+      warn st.inspect
     end
     st = bucket.fillup_conditionally(1)
     warn st.inspect

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -98,7 +98,7 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
     try_fillup = ->(fillup_by, should_have_reached_level, should_have_accepted) {
       counter += 1
       state = bucket.fillup_if_able(fillup_by)
-      assert_equal should_have_accepted, state.did_accept?, "Update #{counter} did_accept should be #{should_have_accepted}"
+      assert_equal should_have_accepted, state.accepted?, "Update #{counter} did_accept should be #{should_have_accepted}"
       assert_in_delta should_have_reached_level, state.level, 0.1
     }
 

--- a/test/leaky_bucket_postgres_test.rb
+++ b/test/leaky_bucket_postgres_test.rb
@@ -155,7 +155,9 @@ class LeakyBucketPostgresTest < ActiveSupport::TestCase
     30.times do
       assert bucket.fillup_conditionally(1).accepted?
     end
-    refute bucket.fillup_conditionally(1).accepted?, "The 31st fillup should be rejected"
+    st = bucket.fillup_conditionally(1)
+    warn st.inspect
+    refute st.accepted?, "The 31st fillup should be rejected"
     sleep 0.6 # Spend enough time to allow the bucket to leak out
     assert bucket.fillup_conditionally(1).accepted?, "Once the bucket has leaked out to 0 the fillup should be accepted again"
   end

--- a/test/leaky_bucket_sqlite_test.rb
+++ b/test/leaky_bucket_sqlite_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require_relative "leaky_bucket_postgres_test"
 
 class LeakyBucketSqliteTest < LeakyBucketPostgresTest
   def setup

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,8 @@ class ActiveSupport::TestCase
   def drop_sqlite_db
     ActiveRecord::Base.connection.close
     FileUtils.rm_rf(test_db_filename)
+    FileUtils.rm_rf(test_db_filename + "-wal")
+    FileUtils.rm_rf(test_db_filename + "-shm")
   end
 
   def test_db_filename

--- a/test/throttle_postgres_test.rb
+++ b/test/throttle_postgres_test.rb
@@ -19,7 +19,7 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
   end
 
   test "throttles using request!() and blocks" do
-    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 3)
+    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, over_time: 1.0, capacity: 30)
 
     29.times do
       throttle.request!
@@ -30,7 +30,7 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
       loop { throttle.request! }
     end
 
-    assert_in_delta err.retry_after, 3, 0.5
+    assert_in_delta err.retry_after, 1, 0.1
     sleep 0.5
 
     # Ensure we are still throttled
@@ -38,9 +38,9 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
       throttle.request!
     end
     assert_equal throttle, err.throttle
-    assert_in_delta err.retry_after, 2.5, 0.5
+    assert_in_delta err.retry_after, 1, 0.1
 
-    sleep(3.05)
+    sleep(1)
     assert_nothing_raised do
       throttle.request!
     end

--- a/test/throttle_postgres_test.rb
+++ b/test/throttle_postgres_test.rb
@@ -3,13 +3,6 @@
 require "test_helper"
 
 class ThrottlePostgresTest < ActiveSupport::TestCase
-  def random_leaky_bucket_name(random: Random.new)
-    (1..32).map do
-      # bytes 97 to 122 are printable lowercase a-z
-      random.rand(97..122)
-    end.pack("C*")
-  end
-
   def setup
     create_postgres_database
   end
@@ -18,29 +11,26 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
     drop_postgres_database
   end
 
-  test "throttles using request!() and blocks" do
-    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, over_time: 1.0, capacity: 30)
+  test "request! installs a block and then removes it and communicates the block using exceptions" do
+    throttle = Pecorino::Throttle.new(key: Random.uuid, over_time: 1.0, capacity: 30)
 
-    29.times do
+    # It must be possible to make exactly 30 requests without getting throttled, even if the
+    # bucket does not leak out at all between the calls
+    30.times do
       throttle.request!
     end
 
-    # Depending on timing either the 31st or the 30th request may start to throttle
-    err = assert_raises Pecorino::Throttle::Throttled do
-      loop { throttle.request! }
-    end
-
-    assert_in_delta err.retry_after, 1, 0.1
-    sleep 0.5
-
-    # Ensure we are still throttled
+    # The 31st request must always fail, as it won't fit into the bucket anymore (even if some
+    # tokens have leaked out by this point)
     err = assert_raises Pecorino::Throttle::Throttled do
       throttle.request!
     end
     assert_equal throttle, err.throttle
     assert_in_delta err.retry_after, 1, 0.1
 
-    sleep(1)
+    # Sleep until the block gets released - the block gets for block_for, which is the time it takes the bucket
+    # to leak out to 0
+    sleep 1.1
     assert_nothing_raised do
       throttle.request!
     end
@@ -48,12 +38,12 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
 
   test "allows the block_for parameter to be omitted" do
     assert_nothing_raised do
-      Pecorino::Throttle.new(key: random_leaky_bucket_name, over_time: 1, capacity: 30)
+      Pecorino::Throttle.new(key: Random.uuid, over_time: 1, capacity: 30)
     end
   end
 
   test "still throttles using request() without raising exceptions" do
-    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 3)
+    throttle = Pecorino::Throttle.new(key: Random.uuid, leak_rate: 30, capacity: 30, block_for: 3)
 
     20.times do
       state = throttle.request
@@ -82,7 +72,7 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
   end
 
   test "able_to_accept? returns the prediction whether the throttle will accept" do
-    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 2)
+    throttle = Pecorino::Throttle.new(key: Random.uuid, leak_rate: 30, capacity: 30, block_for: 2)
 
     assert throttle.able_to_accept?
     assert throttle.able_to_accept?(29)
@@ -99,7 +89,7 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
   end
 
   test "starts to throttle sooner with a higher fillup rate" do
-    throttle = Pecorino::Throttle.new(key: random_leaky_bucket_name, leak_rate: 30, capacity: 30, block_for: 3)
+    throttle = Pecorino::Throttle.new(key: Random.uuid, leak_rate: 30, capacity: 30, block_for: 3)
 
     15.times do
       throttle.request!(2)


### PR DESCRIPTION
For some features - such as "deliver this message at most once" - you need to be able to tell whether a leaky bucket has accepted a topup or not. This is especially treacherous when the bucket has capacity of 1. Observe:

* A bucket of `capacity=1` gets configured for a specific leak rate (say, `over_time=1` for 1 second
* The bucket gets incremented by 1 (one message should be delivered)
* The result is that the bucket "did fill up", so the caller will suppress the message (to the caller it looks like the bucket is already full)

The proper way to deal with this is to have "compare and set" semantics instead:

* A bucket of `capacity=1` gets configured for a specific leak rate (say, `over_time=1` for 1 second
* The bucket gets incremented by 1 (one message should be delivered). The caller gets both the achieved level (`1`) and a flag indicating that the bucket _did_ in fact accept the write
* The caller delivers the "once per second" message
* On second call, after 0.5 seconds, the caller tries to fillup with `1` and gets the the achieved level (which remains `~0.5` because no write was granted) and a flag indicating that the write was rejected

For this we need to juggle some SQL around, but there is nothing making this impossible.