### PR TITLE
Fix Ruby 2.7 v 3 positional args

### DIFF
--- a/lib/pecorino/throttle.rb
+++ b/lib/pecorino/throttle.rb
@@ -54,8 +54,8 @@ class Pecorino::Throttle
   #   the bucket to leak out to the level of 0
   # @param leaky_bucket_options Options for `Pecorino::LeakyBucket.new`
   # @see PecorinoLeakyBucket.new
-  def initialize(key:, block_for: nil, **)
-    @bucket = Pecorino::LeakyBucket.new(key:, **)
+  def initialize(key:, block_for: nil, **leaky_bucket_options)
+    @bucket = Pecorino::LeakyBucket.new(key:, **leaky_bucket_options)
     @key = key.to_s
     @block_for = block_for ? block_for.to_f : (@bucket.capacity / @bucket.leak_rate)
   end


### PR DESCRIPTION
Ruby (https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) deprecated positional arguments in 2.7, it is fully unsupported in Ruby 3.0

This PR fixes a use of this deprecated pattern which was blocking the rails installer command