### PR TITLE
Pass state in the Throttled exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- **BREAKING CHANGE** Remove `Throttle::State#retry_after`, because there is no reasonable value for that member if the throttle is not in the "blocked" state
+- Allow accessing `Throttle::State` from the `Throttled` exception so that the blocked throttle state can be cached downstream (in Rails cache, for example)
+- Make `Throttle#request!` return the new state if there was no exception raised
+
 ## [0.4.1] - 2024-02-11
 
 - Make sure Pecorino works on Ruby 2.7 as well by removing 3.x-exclusive syntax

--- a/test/throttle_postgres_test.rb
+++ b/test/throttle_postgres_test.rb
@@ -14,9 +14,12 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
   test "request! installs a block and then removes it and communicates the block using exceptions" do
     throttle = Pecorino::Throttle.new(key: Random.uuid, over_time: 1.0, capacity: 30)
 
+    state_after_first_request = throttle.request!
+    assert_kind_of Pecorino::Throttle::State, state_after_first_request
+
     # It must be possible to make exactly 30 requests without getting throttled, even if the
     # bucket does not leak out at all between the calls
-    30.times do
+    29.times do
       throttle.request!
     end
 
@@ -27,6 +30,7 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
     end
     assert_equal throttle, err.throttle
     assert_in_delta err.retry_after, 1, 0.1
+    assert_kind_of Pecorino::Throttle::State, err.state
 
     # Sleep until the block gets released - the block gets for block_for, which is the time it takes the bucket
     # to leak out to 0
@@ -57,13 +61,13 @@ class ThrottlePostgresTest < ActiveSupport::TestCase
     state = throttle.request
     assert_predicate state, :blocked?
 
-    assert_in_delta state.retry_after, 3, 0.5
+    assert_in_delta state.blocked_until - Time.now, 3, 0.5
     sleep 0.5
 
     # Ensure we are still throttled
     state = throttle.request
     assert_predicate state, :blocked?
-    assert_in_delta state.retry_after, 2.5, 0.5
+    assert_in_delta state.blocked_until - Time.now, 2.5, 0.5
     assert_kind_of Time, state.blocked_until
 
     sleep(3.05)


### PR DESCRIPTION
When a resource is getting hammered, it can be nice to save the throttle blocked state in a faster/edge datastore, like an ActiveSupport MemoryStore, or in Rails cache. To do that, we need to let the Throttle exception communicate the duration of the block in an easier manner.

State#retry_after is getting removed since it was raising a NoMethodError when accessed for a non-blocked Throttle.

- **BREAKING CHANGE** Remove `Throttle::State#retry_after`, because there is no reasonable value for that member if the throttle is not in the "blocked" state
- Allow accessing `Throttle::State` from the `Throttled` exception so that the blocked throttle state can be cached downstream (in Rails cache, for example)
- Make `Throttle#request!` return the new state if there was no exception raised