### PR TITLE
Add throttle caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add `CachedThrottle` for caching the throttle blocks. This allows protection to the database when the throttle is in a blocked state.
 - Add `Throttle#throttled` for silencing alerts
 - **BREAKING CHANGE** Remove `Throttle::State#retry_after`, because there is no reasonable value for that member if the throttle is not in the "blocked" state
 - Allow accessing `Throttle::State` from the `Throttled` exception so that the blocked throttle state can be cached downstream (in Rails cache, for example)

--- a/lib/pecorino.rb
+++ b/lib/pecorino.rb
@@ -7,6 +7,7 @@ require_relative "pecorino/version"
 require_relative "pecorino/leaky_bucket"
 require_relative "pecorino/throttle"
 require_relative "pecorino/railtie" if defined?(Rails::Railtie)
+require_relative "pecorino/cached_throttle"
 
 module Pecorino
   autoload :Postgres, "pecorino/postgres"

--- a/lib/pecorino/cached_throttle.rb
+++ b/lib/pecorino/cached_throttle.rb
@@ -1,0 +1,72 @@
+# The cached throttles can be used when you want to lift your throttle blocks into
+# a higher-level cache. If you are dealing with clients which are hammering on your
+# throttles a lot, it is useful to have a process-local cache of the timestamp when
+# the blocks that are set are going to expire. If you are running, say, 10 web app
+# containers - and someone is hammering at an endpoint which starts blocking -
+# you don't really need to query your DB for every request. The first request indicated
+# as "blocked" by Pecorino can write a cache entry into a shared in-memory table,
+# and all subsequent calls to the same process can reuse that `blocked_until` value
+# to quickly refuse the request
+class Pecorino::CachedThrottle
+  # @param cache_store[ActiveSupport::Cache::Store] the store for the cached blocks. We recommend a MemoryStore per-process.
+  # @param throttle[Pecorino::Throttle] the throttle to cache
+  def initialize(cache_store, throttle)
+    @cache_store = cache_store
+    @throttle = throttle
+  end
+
+  # @see Pecorino::Throttle#request!
+  def request!(n = 1)
+    blocked_state = cached_blocked_state
+    if blocked_state&.blocked?
+      raise Pecorino::Throttle::Throttled.new(@throttle, blocked_state)
+    else
+      begin
+        @throttle.request!(n)
+      rescue Pecorino::Throttle::Throttled => throttled_ex
+        cache_blocked_state(throttled_ex.state) if throttled_ex.throttle == @throttle
+        raise
+      end
+    end
+  end
+
+  # Returns cached `state` for the throttle if there is a currently active block for that throttle in the cache. Otherwise forwards to underlying throttle.
+  #
+  # @see Pecorino::Throttle#request
+  def request(n = 1)
+    blocked_state = cached_blocked_state
+    return blocked_state if blocked_state&.blocked?
+
+    @throttle.request(n).tap do |state|
+      cache_blocked_state(state) if state.blocked_until
+    end
+  end
+
+  # Returns `false` if there is a currently active block for that throttle in the cache. Otherwise forwards to underlying throttle.
+  #
+  # @see Pecorino::Throttle#able_to_accept?
+  def able_to_accept?(n = 1)
+    blocked_state = cached_blocked_state
+    return false if blocked_state&.blocked?
+    @throttle.able_to_accept?(n)
+  end
+
+  # Does not run the block  if there is a currently active block for that throttle in the cache. Otherwise forwards to underlying throttle.
+  #
+  # @see Pecorino::Throttle#throttled
+  def throttled(&blk)
+    # We can't wrap the implementation of "throttled". Or - we can, but it will be obtuse.
+    return if request(1).blocked?
+    yield
+  end
+
+  private
+
+  def cache_blocked_state(state)
+    @cache_store.write("pcrn-cached-throttle-#{@throttle.key}", state, expires_after: state.blocked_until)
+  end
+
+  def cached_blocked_state
+    @cache_store.read("pcrn-cached-throttle-#{@throttle.key}")
+  end
+end

--- a/lib/pecorino/throttle.rb
+++ b/lib/pecorino/throttle.rb
@@ -89,6 +89,13 @@ class Pecorino::Throttle
     end
   end
 
+  # The key for that throttle. Each key defines a unique throttle based on either a given name or
+  # discriminators. If there is a component you want to key your throttle by, include it in the
+  # `key` keyword argument to the constructor, like `"t-ip-#{request.ip}"`
+  #
+  # @return [String]
+  attr_reader :key
+
   # @param key[String] the key for both the block record and the leaky bucket
   # @param block_for[Numeric] the number of seconds to block any further requests for. Defaults to time it takes
   #   the bucket to leak out to the level of 0

--- a/test/cached_throttle_test.rb
+++ b/test/cached_throttle_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CachedThrottleTest < ActiveSupport::TestCase
+  def setup
+    create_postgres_database
+  end
+
+  def teardown
+    drop_postgres_database
+  end
+
+  test "caches results of request! and correctly raises Throttled until the block is lifted" do
+    store = ActiveSupport::Cache::MemoryStore.new
+    throttle = Pecorino::Throttle.new(key: Random.uuid, capacity: 2, over_time: 1.second, block_for: 2.seconds)
+    cached_throttle = Pecorino::CachedThrottle.new(store, throttle)
+
+    state1 = cached_throttle.request!
+    state2 = cached_throttle.request!
+    ex = assert_raises(Pecorino::Throttle::Throttled) do
+      cached_throttle.request!
+    end
+
+    assert_kind_of Pecorino::Throttle::State, state1
+    assert_kind_of Pecorino::Throttle::State, state2
+
+    assert_equal throttle, ex.throttle
+
+    # Delete the method on the actual throttle as it should not be called anymore until the block is lifted
+    class << throttle
+      undef :request!
+    end
+    assert_raises(Pecorino::Throttle::Throttled) do
+      cached_throttle.request!
+    end
+  end
+
+  test "caches results of able_to_accept? until the block is lifted" do
+    store = ActiveSupport::Cache::MemoryStore.new
+    throttle = Pecorino::Throttle.new(key: Random.uuid, capacity: 2, over_time: 1.second, block_for: 2.seconds)
+    cached_throttle = Pecorino::CachedThrottle.new(store, throttle)
+
+    cached_throttle.request(1)
+    cached_throttle.request(1)
+    cached_throttle.request(1)
+
+    refute cached_throttle.able_to_accept?(1)
+
+    # Delete the method on the actual throttle as it should not be called anymore until the block is lifted
+    class << throttle
+      undef :able_to_accept?
+    end
+
+    refute cached_throttle.able_to_accept?(1)
+  end
+
+  test "caches results of request() and correctly returns cached state until the block is lifted" do
+    store = ActiveSupport::Cache::MemoryStore.new
+    throttle = Pecorino::Throttle.new(key: Random.uuid, capacity: 2, over_time: 1.second, block_for: 2.seconds)
+    cached_throttle = Pecorino::CachedThrottle.new(store, throttle)
+
+    state1 = cached_throttle.request(1)
+    state2 = cached_throttle.request(1)
+    state3 = cached_throttle.request(3)
+
+    assert_kind_of Pecorino::Throttle::State, state1
+    assert_kind_of Pecorino::Throttle::State, state2
+    assert_kind_of Pecorino::Throttle::State, state3
+    assert_predicate state3, :blocked?
+
+    # Delete the method on the actual throttle as it should not be called anymore until the block is lifted
+    class << throttle
+      undef :request
+    end
+    state_from_cache = cached_throttle.request(1)
+    assert_kind_of Pecorino::Throttle::State, state_from_cache
+    assert_predicate state_from_cache, :blocked?
+  end
+
+  test "does not run block in throttled() until the block is lifted" do
+    store = ActiveSupport::Cache::MemoryStore.new
+    throttle = Pecorino::Throttle.new(key: Random.uuid, capacity: 2, over_time: 1.second, block_for: 2.seconds)
+    cached_throttle = Pecorino::CachedThrottle.new(store, throttle)
+
+    assert_equal 123, cached_throttle.throttled { 123 }
+    assert_equal 234, cached_throttle.throttled { 234 }
+    assert_nil cached_throttle.throttled { 345 }
+
+    # Delete the method on the actual throttle as it should not be called anymore until the block is lifted
+    class << throttle
+      undef :throttled
+    end
+
+    assert_nil cached_throttle.throttled { 345 }
+  end
+end


### PR DESCRIPTION
The cached throttles can be used when you want to lift your throttle blocks into a higher-level cache. If you are dealing with clients which are hammering on your throttles a lot, it is useful to have a process-local cache of the timestamp when the blocks that are set are going to expire. If you are running, say, 10 web app containers - and someone is hammering at an endpoint which starts blocking - you don't really need to query your DB for every request. The first request indicated as "blocked" by Pecorino can write a cache entry into a shared in-memory table, and all subsequent calls to the same process can reuse that `blocked_until` value to quickly refuse the request