### PR TITLE
Remove mention of GoodJob

### DIFF
--- a/lib/pecorino/install_generator.rb
+++ b/lib/pecorino/install_generator.rb
@@ -5,8 +5,8 @@ require "rails/generators/active_record"
 
 module Pecorino
   #
-  # Rails generator used for setting up GoodJob in a Rails application.
-  # Run it with +bin/rails g good_job:install+ in your console.
+  # Rails generator used for setting up Pecorino in a Rails application.
+  # Run it with +bin/rails g pecorino:install+ in your console.
   #
   class InstallGenerator < Rails::Generators::Base
     include ActiveRecord::Generators::Migration


### PR DESCRIPTION
GoodJob is a great gem, but doesn't have much to do with this gem.

Let's adjust comment slightly to remove mentions of GoodJob.