### PR TITLE
Be more specific (and liberal) with Ruby version requirements

### DIFF
--- a/gemfiles/.bundle/config
+++ b/gemfiles/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_RETRY: "1"

--- a/lib/pecorino.rb
+++ b/lib/pecorino.rb
@@ -13,6 +13,7 @@ module Pecorino
   autoload :CachedThrottle, "pecorino/cached_throttle"
 
   module Adapters
+    autoload :ConnectionShim, "pecorino/adapters/connection_shim"
     autoload :MemoryAdapter, "pecorino/adapters/memory_adapter"
     autoload :PostgresAdapter, "pecorino/adapters/postgres_adapter"
     autoload :SqliteAdapter, "pecorino/adapters/sqlite_adapter"
@@ -75,4 +76,6 @@ module Pecorino
       raise "Pecorino does not support the #{adapter_name} database just yet"
     end
   end
+
+  @adapter = nil # Avoid "instance variable @adapter not initialized" warning on 2.7x
 end

--- a/lib/pecorino/adapters/connection_shim.rb
+++ b/lib/pecorino/adapters/connection_shim.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pecorino::Adapters::ConnectionShim
+  def sanitize_sql_array(*args)
+    raise "No @model_class in #{inspect} - unable to obtain connection" unless @model_class
+    @model_class.sanitize_sql_array(*args)
+  end
+
+  def with_connection
+    raise "No @model_class in #{inspect} - unable to obtain connection" unless @model_class
+    @model_class.connection.pool.with_connection do |conn|
+      conn.uncached { yield(conn) }
+    end
+  end
+end

--- a/lib/pecorino/adapters/sqlite_adapter.rb
+++ b/lib/pecorino/adapters/sqlite_adapter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Pecorino::Adapters::SqliteAdapter
+  include Pecorino::Adapters::ConnectionShim
+
   def initialize(model_class)
     @model_class = model_class
   end
@@ -21,7 +23,7 @@ class Pecorino::Adapters::SqliteAdapter
     # The `level` of the bucket is what got stored at `last_touched_at` time, and we can
     # extrapolate from it to see how many tokens have leaked out since `last_touched_at` -
     # we don't need to UPDATE the value in the bucket here
-    sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    sql = sanitize_sql_array([<<~SQL, query_params])
       SELECT
         MAX(
           0.0, MIN(
@@ -37,7 +39,7 @@ class Pecorino::Adapters::SqliteAdapter
 
     # If the return value of the query is a NULL it means no such bucket exists,
     # so we assume the bucket is empty
-    current_level = @model_class.connection.uncached { @model_class.connection.select_value(sql) } || 0.0
+    current_level = with_connection { |c| c.select_value(sql) } || 0.0
     [current_level, capacity - current_level.abs < 0.01]
   end
 
@@ -57,7 +59,7 @@ class Pecorino::Adapters::SqliteAdapter
       fillup: n_tokens.to_f
     }
 
-    sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    sql = sanitize_sql_array([<<~SQL, query_params])
       INSERT INTO pecorino_leaky_buckets AS t
         (key, last_touched_at, may_be_deleted_after, level)
       VALUES
@@ -91,7 +93,7 @@ class Pecorino::Adapters::SqliteAdapter
     # query as a repeat (since we use "select_one" for the RETURNING bit) and will not call into Postgres
     # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
     # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
-    upserted = @model_class.connection.uncached { @model_class.connection.select_one(sql) }
+    upserted = with_connection { |c| c.select_one(sql) }
     capped_level_after_fillup, one_if_did_overflow = upserted.fetch("level"), upserted.fetch("did_overflow")
     [capped_level_after_fillup, one_if_did_overflow == 1]
   end
@@ -115,7 +117,7 @@ class Pecorino::Adapters::SqliteAdapter
     # Sadly with SQLite we need to do an INSERT first, because otherwise the inserted row is visible
     # to the WITH clause, so we cannot combine the initial fillup and the update into one statement.
     # This shuld be fine however since we will suppress the INSERT on a key conflict
-    insert_sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    insert_sql = sanitize_sql_array([<<~SQL, query_params])
       INSERT INTO pecorino_leaky_buckets AS t
         (key, last_touched_at, may_be_deleted_after, level)
       VALUES
@@ -130,9 +132,9 @@ class Pecorino::Adapters::SqliteAdapter
       -- so that it can't be deleted between our INSERT and our UPDATE
         may_be_deleted_after = EXCLUDED.may_be_deleted_after
     SQL
-    @model_class.connection.execute(insert_sql)
+    with_connection { |c| c.execute(insert_sql) }
 
-    sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    sql = sanitize_sql_array([<<~SQL, query_params])
       -- With SQLite MATERIALIZED has to be used so that level_post is calculated before the UPDATE takes effect
       WITH pre(level_post_with_uncapped_fillup, level_post) AS MATERIALIZED (
         SELECT
@@ -156,7 +158,7 @@ class Pecorino::Adapters::SqliteAdapter
         level AS level_after
     SQL
 
-    upserted = @model_class.connection.uncached { @model_class.connection.select_one(sql) }
+    upserted = with_connection { |c| c.select_one(sql) }
     level_after = upserted.fetch("level_after")
     level_before = upserted.fetch("level_before")
     [level_after, level_after >= capacity, level_after != level_before]
@@ -165,7 +167,7 @@ class Pecorino::Adapters::SqliteAdapter
   def set_block(key:, block_for:)
     raise ArgumentError, "block_for must be positive" unless block_for > 0
     query_params = {key: key.to_s, block_for: block_for.to_f, now_s: Time.now.to_f}
-    block_set_query = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    block_set_query = sanitize_sql_array([<<~SQL, query_params])
       INSERT INTO pecorino_blocks AS t
         (key, blocked_until)
       VALUES
@@ -174,13 +176,13 @@ class Pecorino::Adapters::SqliteAdapter
         blocked_until = MAX(EXCLUDED.blocked_until, t.blocked_until)
       RETURNING blocked_until;
     SQL
-    blocked_until_s = @model_class.connection.uncached { @model_class.connection.select_value(block_set_query) }
+    blocked_until_s = with_connection { |c| c.select_value(block_set_query) }
     Time.at(blocked_until_s)
   end
 
   def blocked_until(key:)
     now_s = Time.now.to_f
-    block_check_query = @model_class.sanitize_sql_array([<<~SQL, {now_s: now_s, key: key}])
+    block_check_query = sanitize_sql_array([<<~SQL, {now_s: now_s, key: key}])
       SELECT
         blocked_until
       FROM
@@ -188,14 +190,16 @@ class Pecorino::Adapters::SqliteAdapter
       WHERE
         key = :key AND blocked_until >= :now_s LIMIT 1
     SQL
-    blocked_until_s = @model_class.connection.uncached { @model_class.connection.select_value(block_check_query) }
+    blocked_until_s = with_connection { |c| c.select_value(block_check_query) }
     blocked_until_s && Time.at(blocked_until_s)
   end
 
   def prune
     now_s = Time.now.to_f
-    @model_class.connection.execute("DELETE FROM pecorino_blocks WHERE blocked_until < ?", now_s)
-    @model_class.connection.execute("DELETE FROM pecorino_leaky_buckets WHERE may_be_deleted_after < ?", now_s)
+    with_connection do |c|
+      c.execute("DELETE FROM pecorino_blocks WHERE blocked_until < ?", now_s)
+      c.execute("DELETE FROM pecorino_leaky_buckets WHERE may_be_deleted_after < ?", now_s)
+    end
   end
 
   def create_tables(active_record_schema)

--- a/lib/pecorino/cached_throttle.rb
+++ b/lib/pecorino/cached_throttle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The cached throttles can be used when you want to lift your throttle blocks into
 # a higher-level cache. If you are dealing with clients which are hammering on your
 # throttles a lot, it is useful to have a process-local cache of the timestamp when

--- a/test/adapters/adapter_test_methods.rb
+++ b/test/adapters/adapter_test_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The module contains the conformance tests for a storage adapter for Pecorino. A well-behaved adapter
 # should pass all of these tests. When creating a new adapter include this module in your test case
 # and overload the `create_adapter` method

--- a/test/adapters/memory_adapter_test.rb
+++ b/test/adapters/memory_adapter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require_relative "adapter_test_methods"
 

--- a/test/adapters/postgres_adapter_test.rb
+++ b/test/adapters/postgres_adapter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require_relative "adapter_test_methods"
 

--- a/test/adapters/redis_adapter_test.rb
+++ b/test/adapters/redis_adapter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require_relative "adapter_test_methods"
 

--- a/test/adapters/sqlite_adapter_test.rb
+++ b/test/adapters/sqlite_adapter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require_relative "adapter_test_methods"
 

--- a/test/block_test.rb
+++ b/test/block_test.rb
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
 
-require "test_helper"
+require_relative "test_helper"
 require "base64"
 
 class BlockTest < ActiveSupport::TestCase
+  def setup
+    Pecorino.adapter = Pecorino::Adapters::MemoryAdapter.new
+  end
+
   test "sets a block" do
     k = Base64.strict_encode64(Random.bytes(4))
     assert_nil Pecorino::Block.blocked_until(key: k)
-    assert Pecorino::Block.set!(key: k, block_for: 30.minutes)
+    assert Pecorino::Block.set!(key: k, block_for: 30 * 60)
 
     blocked_until = Pecorino::Block.blocked_until(key: k)
-    assert_in_delta Time.now + 30.minutes, blocked_until, 10
+    assert_in_delta Time.now + (30 * 60), blocked_until, 10
   end
 
   test "does not return a block which has lapsed" do
     k = Base64.strict_encode64(Random.bytes(4))
     assert_nil Pecorino::Block.blocked_until(key: k)
-    Pecorino::Block.set!(key: k, block_for: -30.minutes)
+    Pecorino::Block.set!(key: k, block_for: -30 * 60)
     blocked_until = Pecorino::Block.blocked_until(key: k)
     assert_nil blocked_until
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "bundler"
+Bundler.setup
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "pecorino"
 


### PR DESCRIPTION
There is zero issue with supporting 2.7 and older Rails, we just need to carefully figure out how to handle AR connections in tests and how to dissociate our calls from ActiveRecord well. Nothing that Pecorino does (aside from migration format) is ActiveRecord specific, but we still want to integrate well with ActiveRecord.

And it is reasonable for Pecorino to have the minimum requirement tested by default.