### PR TITLE
Fix race in conditional fillup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Make sure `conditional_fillup` does not make the bucket exceed capacity due to data races / rapid queries.
+
 ## 0.7.4
 
 - Ensure deprecated ActiveRecord::Base.connection is replaced with ActiveRecord::Base.connection_pool.with_connection. This prevents permanent connection checkout

--- a/gemfiles/.bundle/config
+++ b/gemfiles/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_RETRY: "1"

--- a/lib/pecorino.rb
+++ b/lib/pecorino.rb
@@ -13,6 +13,7 @@ module Pecorino
   autoload :CachedThrottle, "pecorino/cached_throttle"
 
   module Adapters
+    autoload :ConnectionShim, "pecorino/adapters/connection_shim"
     autoload :MemoryAdapter, "pecorino/adapters/memory_adapter"
     autoload :PostgresAdapter, "pecorino/adapters/postgres_adapter"
     autoload :SqliteAdapter, "pecorino/adapters/sqlite_adapter"
@@ -75,4 +76,6 @@ module Pecorino
       raise "Pecorino does not support the #{adapter_name} database just yet"
     end
   end
+
+  @adapter = nil # Avoid "instance variable @adapter not initialized" warning on 2.7x
 end

--- a/lib/pecorino/adapters/connection_shim.rb
+++ b/lib/pecorino/adapters/connection_shim.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pecorino::Adapters::ConnectionShim
+  def sanitize_sql_array(*args)
+    raise "No @model_class in #{inspect} - unable to obtain connection" unless @model_class
+    @model_class.sanitize_sql_array(*args)
+  end
+
+  def with_connection
+    raise "No @model_class in #{inspect} - unable to obtain connection" unless @model_class
+    @model_class.connection_pool.with_connection do |conn|
+      conn.uncached { yield(conn) }
+    end
+  end
+end

--- a/lib/pecorino/adapters/postgres_adapter.rb
+++ b/lib/pecorino/adapters/postgres_adapter.rb
@@ -32,7 +32,7 @@ class Pecorino::Adapters::PostgresAdapter
 
     # If the return value of the query is a NULL it means no such bucket exists,
     # so we assume the bucket is empty
-    current_level = with_connection  { |c| c.select_value(sql) } || 0.0
+    current_level = with_connection { |c| c.select_value(sql) } || 0.0
     [current_level, capacity - current_level.abs < 0.01]
   end
 
@@ -85,7 +85,7 @@ class Pecorino::Adapters::PostgresAdapter
     # query as a repeat (since we use "select_one" for the RETURNING bit) and will not call into Postgres
     # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
     # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
-    upserted = with_connection  { |c| c.select_one(sql) }
+    upserted = with_connection { |c| c.select_one(sql) }
     capped_level_after_fillup, at_capacity = upserted.fetch("level"), upserted.fetch("at_capacity")
     [capped_level_after_fillup, at_capacity]
   end

--- a/lib/pecorino/adapters/postgres_adapter.rb
+++ b/lib/pecorino/adapters/postgres_adapter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Pecorino::Adapters::PostgresAdapter
+  include Pecorino::Adapters::ConnectionShim
+
   def initialize(model_class)
     @model_class = model_class
   end
@@ -14,7 +16,7 @@ class Pecorino::Adapters::PostgresAdapter
     # The `level` of the bucket is what got stored at `last_touched_at` time, and we can
     # extrapolate from it to see how many tokens have leaked out since `last_touched_at` -
     # we don't need to UPDATE the value in the bucket here
-    sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    sql = sanitize_sql_array([<<~SQL, query_params])
       SELECT
         GREATEST(
           0.0, LEAST(
@@ -30,7 +32,7 @@ class Pecorino::Adapters::PostgresAdapter
 
     # If the return value of the query is a NULL it means no such bucket exists,
     # so we assume the bucket is empty
-    current_level = @model_class.connection_pool.with_connection { |connection| connection.uncached { connection.select_value(sql) } } || 0.0
+    current_level = with_connection  { |c| c.select_value(sql) } || 0.0
     [current_level, capacity - current_level.abs < 0.01]
   end
 
@@ -49,7 +51,7 @@ class Pecorino::Adapters::PostgresAdapter
       fillup: n_tokens.to_f
     }
 
-    sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    sql = sanitize_sql_array([<<~SQL, query_params])
       INSERT INTO pecorino_leaky_buckets AS t
         (key, last_touched_at, may_be_deleted_after, level)
       VALUES
@@ -83,7 +85,7 @@ class Pecorino::Adapters::PostgresAdapter
     # query as a repeat (since we use "select_one" for the RETURNING bit) and will not call into Postgres
     # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
     # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
-    upserted = @model_class.connection_pool.with_connection { |connection| connection.uncached { connection.select_one(sql) } }
+    upserted = with_connection  { |c| c.select_one(sql) }
     capped_level_after_fillup, at_capacity = upserted.fetch("level"), upserted.fetch("at_capacity")
     [capped_level_after_fillup, at_capacity]
   end
@@ -103,54 +105,87 @@ class Pecorino::Adapters::PostgresAdapter
       fillup: n_tokens.to_f
     }
 
-    sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
-      WITH pre AS MATERIALIZED (
-        SELECT
-          -- Note the double clamping here. First we clamp the "current level - leak" to not go below zero,
-          -- then we also clamp the above + fillup to not go below 0
-          GREATEST(0.0, 
-              GREATEST(0.0, level - (EXTRACT(EPOCH FROM (clock_timestamp() - last_touched_at)) * :leak_rate)) + :fillup
-          ) AS level_post_with_uncapped_fillup,
-          GREATEST(0.0,
-              level - (EXTRACT(EPOCH FROM (clock_timestamp() - last_touched_at)) * :leak_rate)
-          ) AS level_post
-        FROM pecorino_leaky_buckets
-        WHERE key = :key
-      )
-      INSERT INTO pecorino_leaky_buckets AS t
-        (key, last_touched_at, may_be_deleted_after, level)
-      VALUES
-        (
-          :key,
-          clock_timestamp(),
-          clock_timestamp() + ':delete_after_s second'::interval,
-          GREATEST(0.0,
-            (CASE WHEN :fillup > :capacity THEN 0.0 ELSE :fillup END)
-          )
-        )
-      ON CONFLICT (key) DO UPDATE SET
-        last_touched_at = EXCLUDED.last_touched_at,
-        may_be_deleted_after = EXCLUDED.may_be_deleted_after,
-        level = CASE WHEN (SELECT level_post_with_uncapped_fillup FROM pre) <= :capacity THEN
-          (SELECT level_post_with_uncapped_fillup FROM pre)
-        ELSE
-          (SELECT level_post FROM pre)
-        END
-      RETURNING
-        COALESCE((SELECT level_post FROM pre), 0.0) AS level_before,
-        level AS level_after
-    SQL
+    # Use explicit transaction with separate INSERT and UPDATE statements
+    # This ensures proper locking and is more portable across RDBMSes
+    # READ COMMITTED (PostgreSQL's default) combined with SELECT FOR UPDATE provides row-level locking
+    # that prevents concurrent modifications, which is sufficient for our use case.
+    # SELECT FOR UPDATE locks the row until the transaction commits, preventing race conditions.
+    # This is more performant than SERIALIZABLE or REPEATABLE READ while still preventing race conditions.
+    with_connection do |connection|
+      connection.uncached do
+        connection.transaction(isolation: :read_committed) do
+          # Step 1: Ensure the row exists (this serializes concurrent inserts)
+          insert_sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+            INSERT INTO pecorino_leaky_buckets
+              (key, last_touched_at, may_be_deleted_after, level)
+            VALUES
+              (
+                :key,
+                clock_timestamp(),
+                clock_timestamp() + ':delete_after_s second'::interval,
+                0.0
+              )
+            ON CONFLICT (key) DO NOTHING
+          SQL
+          connection.execute(insert_sql)
 
-    upserted = @model_class.connection_pool.with_connection { |connection| connection.uncached { connection.select_one(sql) } }
-    level_after = upserted.fetch("level_after")
-    level_before = upserted.fetch("level_before")
-    [level_after, level_after >= capacity, level_after != level_before]
+          # Step 2: Lock the row and read current state
+          # The FOR UPDATE lock will be held until the transaction commits
+          lock_sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+            SELECT
+              level,
+              last_touched_at,
+              GREATEST(0.0,
+                level - (EXTRACT(EPOCH FROM (clock_timestamp() - last_touched_at)) * :leak_rate)
+              ) AS level_after_leak
+            FROM pecorino_leaky_buckets
+            WHERE key = :key
+            FOR UPDATE
+          SQL
+          current = connection.select_one(lock_sql)
+
+          # If row doesn't exist (shouldn't happen after INSERT, but handle it)
+          if current.nil?
+            level_before = 0.0
+            level_post_with_uncapped_fillup = query_params[:fillup]
+          else
+            level_before = current.fetch("level_after_leak").to_f
+            level_post_with_uncapped_fillup = level_before + query_params[:fillup]
+          end
+
+          # Step 3: Calculate new level conditionally
+          # Ensure level_before is non-negative (should be handled by GREATEST, but be safe)
+          level_before = [level_before, 0.0].max
+
+          new_level = if level_post_with_uncapped_fillup <= query_params[:capacity]
+            [level_post_with_uncapped_fillup, 0.0].max
+          else
+            level_before
+          end
+
+          # Step 4: Update the row (lock is still held from Step 2)
+          update_sql = @model_class.sanitize_sql_array([<<~SQL, query_params.merge(new_level: new_level)])
+            UPDATE pecorino_leaky_buckets
+            SET
+              last_touched_at = clock_timestamp(),
+              may_be_deleted_after = clock_timestamp() + ':delete_after_s second'::interval,
+              level = GREATEST(0.0, :new_level)
+            WHERE key = :key
+            RETURNING level
+          SQL
+
+          updated = connection.select_one(update_sql)
+          level_after = updated.fetch("level").to_f
+          [level_after, level_after >= capacity, level_after != level_before]
+        end
+      end
+    end
   end
 
   def set_block(key:, block_for:)
     raise ArgumentError, "block_for must be positive" unless block_for > 0
     query_params = {key: key.to_s, block_for: block_for.to_f}
-    block_set_query = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    block_set_query = sanitize_sql_array([<<~SQL, query_params])
       INSERT INTO pecorino_blocks AS t
         (key, blocked_until)
       VALUES
@@ -159,20 +194,20 @@ class Pecorino::Adapters::PostgresAdapter
         blocked_until = GREATEST(EXCLUDED.blocked_until, t.blocked_until)
       RETURNING blocked_until
     SQL
-    @model_class.connection_pool.with_connection { |connection| connection.uncached { connection.select_value(block_set_query) } }
+    with_connection { |c| c.select_value(block_set_query) }
   end
 
   def blocked_until(key:)
-    block_check_query = @model_class.sanitize_sql_array([<<~SQL, key])
+    block_check_query = sanitize_sql_array([<<~SQL, key])
       SELECT blocked_until FROM pecorino_blocks WHERE key = ? AND blocked_until >= clock_timestamp() LIMIT 1
     SQL
-    @model_class.connection_pool.with_connection { |connection| connection.uncached { connection.select_value(block_check_query) } }
+    with_connection { |c| c.select_value(block_check_query) }
   end
 
   def prune
-    @model_class.connection_pool.with_connection do |connection|
-      connection.execute("DELETE FROM pecorino_blocks WHERE blocked_until < NOW()")
-      connection.execute("DELETE FROM pecorino_leaky_buckets WHERE may_be_deleted_after < NOW()")
+    with_connection do |c|
+      c.execute("DELETE FROM pecorino_blocks WHERE blocked_until < NOW()")
+      c.execute("DELETE FROM pecorino_leaky_buckets WHERE may_be_deleted_after < NOW()")
     end
   end
 

--- a/lib/pecorino/adapters/sqlite_adapter.rb
+++ b/lib/pecorino/adapters/sqlite_adapter.rb
@@ -99,20 +99,24 @@ class Pecorino::Adapters::SqliteAdapter
     # until the bucket may be deleted.
     may_be_deleted_after_seconds = (capacity.to_f / leak_rate.to_f) * 2.0
 
-    # Execute both INSERT and UPDATE in a single transaction to avoid race conditions
-    # where tokens leak between the INSERT and UPDATE operations
-    with_connection do |connection|
-      connection.transaction do
-        # Calculate now_s once at the start of the transaction
-        now_s = Time.now.to_f
-
-<<<<<<< HEAD
     # Use explicit transaction with separate INSERT and UPDATE statements
     # This ensures proper locking and is more portable across RDBMSes
     # SQLite uses file-level locking and SERIALIZABLE isolation by default,
     # so the transaction itself provides the necessary isolation to prevent race conditions.
     with_connection do |connection|
       connection.transaction do
+        # Calculate now_s once at the start of the transaction
+        now_s = Time.now.to_f
+
+        query_params = {
+          key: key.to_s,
+          capacity: capacity.to_f,
+          delete_after_s: may_be_deleted_after_seconds,
+          leak_rate: leak_rate.to_f,
+          now_s: now_s,
+          fillup: n_tokens.to_f
+        }
+
         # Step 1: Ensure the row exists (this serializes concurrent inserts)
         insert_sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
           INSERT INTO pecorino_leaky_buckets

--- a/lib/pecorino/adapters/sqlite_adapter.rb
+++ b/lib/pecorino/adapters/sqlite_adapter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Pecorino::Adapters::SqliteAdapter
+  include Pecorino::Adapters::ConnectionShim
+
   def initialize(model_class)
     @model_class = model_class
   end
@@ -21,7 +23,7 @@ class Pecorino::Adapters::SqliteAdapter
     # The `level` of the bucket is what got stored at `last_touched_at` time, and we can
     # extrapolate from it to see how many tokens have leaked out since `last_touched_at` -
     # we don't need to UPDATE the value in the bucket here
-    sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    sql = sanitize_sql_array([<<~SQL, query_params])
       SELECT
         MAX(
           0.0, MIN(
@@ -37,7 +39,7 @@ class Pecorino::Adapters::SqliteAdapter
 
     # If the return value of the query is a NULL it means no such bucket exists,
     # so we assume the bucket is empty
-    current_level = @model_class.connection_pool.with_connection { |connection| connection.uncached { connection.select_value(sql) } } || 0.0
+    current_level = with_connection { |c| c.select_value(sql) } || 0.0
     [current_level, capacity - current_level.abs < 0.01]
   end
 
@@ -57,7 +59,7 @@ class Pecorino::Adapters::SqliteAdapter
       fillup: n_tokens.to_f
     }
 
-    sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    sql = sanitize_sql_array([<<~SQL, query_params])
       INSERT INTO pecorino_leaky_buckets AS t
         (key, last_touched_at, may_be_deleted_after, level)
       VALUES
@@ -87,11 +89,7 @@ class Pecorino::Adapters::SqliteAdapter
         level >= :capacity AS did_overflow
     SQL
 
-    # Note the use of .uncached here. The AR query cache will actually see our
-    # query as a repeat (since we use "select_one" for the RETURNING bit) and will not call into Postgres
-    # correctly, thus the clock_timestamp() value would be frozen between calls. We don't want that here.
-    # See https://stackoverflow.com/questions/73184531/why-would-postgres-clock-timestamp-freeze-inside-a-rails-unit-test
-    upserted = @model_class.connection_pool.with_connection { |connection| connection.uncached { connection.select_one(sql) } }
+    upserted = with_connection { |c| c.select_one(sql) }
     capped_level_after_fillup, one_if_did_overflow = upserted.fetch("level"), upserted.fetch("did_overflow")
     [capped_level_after_fillup, one_if_did_overflow == 1]
   end
@@ -101,71 +99,98 @@ class Pecorino::Adapters::SqliteAdapter
     # until the bucket may be deleted.
     may_be_deleted_after_seconds = (capacity.to_f / leak_rate.to_f) * 2.0
 
-    # Create the leaky bucket if it does not exist, and update
-    # to the new level, taking the leak rate into account - if the bucket exists.
-    query_params = {
-      key: key.to_s,
-      capacity: capacity.to_f,
-      delete_after_s: may_be_deleted_after_seconds,
-      leak_rate: leak_rate.to_f,
-      now_s: Time.now.to_f, # See above as to why we are using a time value passed in
-      fillup: n_tokens.to_f
-    }
+    # Execute both INSERT and UPDATE in a single transaction to avoid race conditions
+    # where tokens leak between the INSERT and UPDATE operations
+    with_connection do |connection|
+      connection.transaction do
+        # Calculate now_s once at the start of the transaction
+        now_s = Time.now.to_f
 
-    # Sadly with SQLite we need to do an INSERT first, because otherwise the inserted row is visible
-    # to the WITH clause, so we cannot combine the initial fillup and the update into one statement.
-    # This shuld be fine however since we will suppress the INSERT on a key conflict
-    insert_sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
-      INSERT INTO pecorino_leaky_buckets AS t
-        (key, last_touched_at, may_be_deleted_after, level)
-      VALUES
-        (
-          :key,
-          :now_s, -- Precision loss must be avoided here as it is used for calculations
-          DATETIME('now', '+:delete_after_s seconds'), -- Precision loss is acceptable here
-          0.0
-        )
-      ON CONFLICT (key) DO UPDATE SET
-      -- Make sure we extend the lifetime of the row
-      -- so that it can't be deleted between our INSERT and our UPDATE
-        may_be_deleted_after = EXCLUDED.may_be_deleted_after
-    SQL
-    @model_class.connection_pool.with_connection { |connection| connection.execute(insert_sql) }
+<<<<<<< HEAD
+    # Use explicit transaction with separate INSERT and UPDATE statements
+    # This ensures proper locking and is more portable across RDBMSes
+    # SQLite uses file-level locking and SERIALIZABLE isolation by default,
+    # so the transaction itself provides the necessary isolation to prevent race conditions.
+    with_connection do |connection|
+      connection.transaction do
+        # Step 1: Ensure the row exists (this serializes concurrent inserts)
+        insert_sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+          INSERT INTO pecorino_leaky_buckets
+            (key, last_touched_at, may_be_deleted_after, level)
+          VALUES
+            (
+              :key,
+              :now_s,
+              DATETIME('now', '+:delete_after_s seconds'),
+              0.0
+            )
+          ON CONFLICT (key) DO NOTHING
+        SQL
+        connection.execute(insert_sql)
 
-    sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
-      -- With SQLite MATERIALIZED has to be used so that level_post is calculated before the UPDATE takes effect
-      WITH pre(level_post_with_uncapped_fillup, level_post) AS MATERIALIZED (
-        SELECT
-          -- Note the double clamping here. First we clamp the "current level - leak" to not go below zero,
-          -- then we also clamp the above + fillup to not go below 0
-          MAX(0.0, MAX(0.0, level - ((:now_s - last_touched_at) * :leak_rate)) + :fillup) AS level_post_with_uncapped_fillup,
-          MAX(0.0, level - ((:now_s - last_touched_at) * :leak_rate)) AS level_post
-        FROM
-          pecorino_leaky_buckets
-        WHERE key = :key
-      ) UPDATE pecorino_leaky_buckets SET
-        last_touched_at = :now_s,
-        may_be_deleted_after = DATETIME('now', '+:delete_after_s seconds'),
-        level = CASE WHEN (SELECT level_post_with_uncapped_fillup FROM pre) <= :capacity THEN
-          (SELECT level_post_with_uncapped_fillup FROM pre)
-        ELSE
-          (SELECT level_post FROM pre)
-        END
-      RETURNING
-        (SELECT level_post FROM pre) AS level_before,
-        level AS level_after
-    SQL
+        # Step 2: Read current state
+        # SQLite uses file-level locking and SERIALIZABLE isolation by default,
+        # so the transaction itself provides the necessary isolation without FOR UPDATE
+        lock_sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+          SELECT
+            level,
+            last_touched_at,
+            MAX(0.0,
+              level - ((:now_s - last_touched_at) * :leak_rate)
+            ) AS level_after_leak
+          FROM pecorino_leaky_buckets
+          WHERE key = :key
+        SQL
+        current = connection.select_one(lock_sql)
 
-    upserted = @model_class.connection_pool.with_connection { |connection| connection.uncached { connection.select_one(sql) } }
-    level_after = upserted.fetch("level_after")
-    level_before = upserted.fetch("level_before")
-    [level_after, level_after >= capacity, level_after != level_before]
+        # If row doesn't exist (shouldn't happen after INSERT, but handle it)
+        if current.nil?
+          level_before = 0.0
+          level_post_with_uncapped_fillup = query_params[:fillup]
+        else
+          level_before = current.fetch("level_after_leak").to_f
+          level_post_with_uncapped_fillup = level_before + query_params[:fillup]
+        end
+
+        # Step 3: Calculate new level conditionally
+        # Ensure level_before is non-negative (should be handled by MAX, but be safe)
+        level_before = [level_before, 0.0].max
+
+        new_level = if level_post_with_uncapped_fillup <= query_params[:capacity]
+          [level_post_with_uncapped_fillup, 0.0].max
+        else
+          level_before
+        end
+
+        # Step 4: Update the row (transaction isolation ensures no concurrent modifications)
+        update_sql = @model_class.sanitize_sql_array([<<~SQL, query_params.merge(new_level: new_level)])
+          UPDATE pecorino_leaky_buckets
+          SET
+            last_touched_at = :now_s,
+            may_be_deleted_after = DATETIME('now', '+:delete_after_s seconds'),
+            level = MAX(0.0, :new_level)
+          WHERE key = :key
+        SQL
+
+        connection.execute(update_sql)
+
+        # Step 5: Read the final level to return
+        final_sql = @model_class.sanitize_sql_array([<<~SQL, query_params])
+          SELECT level
+          FROM pecorino_leaky_buckets
+          WHERE key = :key
+        SQL
+        final = connection.select_one(final_sql)
+        level_after = final.fetch("level").to_f
+        [level_after, level_after >= capacity, level_after != level_before]
+      end
+    end
   end
 
   def set_block(key:, block_for:)
     raise ArgumentError, "block_for must be positive" unless block_for > 0
     query_params = {key: key.to_s, block_for: block_for.to_f, now_s: Time.now.to_f}
-    block_set_query = @model_class.sanitize_sql_array([<<~SQL, query_params])
+    block_set_query = sanitize_sql_array([<<~SQL, query_params])
       INSERT INTO pecorino_blocks AS t
         (key, blocked_until)
       VALUES
@@ -174,13 +199,13 @@ class Pecorino::Adapters::SqliteAdapter
         blocked_until = MAX(EXCLUDED.blocked_until, t.blocked_until)
       RETURNING blocked_until;
     SQL
-    blocked_until_s = @model_class.connection_pool.with_connection { |connection| connection.uncached { connection.select_value(block_set_query) } }
+    blocked_until_s = with_connection { |c| c.select_value(block_set_query) }
     Time.at(blocked_until_s)
   end
 
   def blocked_until(key:)
     now_s = Time.now.to_f
-    block_check_query = @model_class.sanitize_sql_array([<<~SQL, {now_s: now_s, key: key}])
+    block_check_query = sanitize_sql_array([<<~SQL, {now_s: now_s, key: key}])
       SELECT
         blocked_until
       FROM
@@ -188,15 +213,15 @@ class Pecorino::Adapters::SqliteAdapter
       WHERE
         key = :key AND blocked_until >= :now_s LIMIT 1
     SQL
-    blocked_until_s = @model_class.connection_pool.with_connection { |connection| connection.uncached { connection.select_value(block_check_query) } }
+    blocked_until_s = with_connection { |c| c.select_value(block_check_query) }
     blocked_until_s && Time.at(blocked_until_s)
   end
 
   def prune
     now_s = Time.now.to_f
-    @model_class.connection_pool.with_connection do |connection|
-      connection.execute("DELETE FROM pecorino_blocks WHERE blocked_until < ?", now_s)
-      connection.execute("DELETE FROM pecorino_leaky_buckets WHERE may_be_deleted_after < ?", now_s)
+    with_connection do |c|
+      c.execute("DELETE FROM pecorino_blocks WHERE blocked_until < ?", now_s)
+      c.execute("DELETE FROM pecorino_leaky_buckets WHERE may_be_deleted_after < ?", now_s)
     end
   end
 

--- a/lib/pecorino/cached_throttle.rb
+++ b/lib/pecorino/cached_throttle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The cached throttles can be used when you want to lift your throttle blocks into
 # a higher-level cache. If you are dealing with clients which are hammering on your
 # throttles a lot, it is useful to have a process-local cache of the timestamp when

--- a/rbi/pecorino.rbi
+++ b/rbi/pecorino.rbi
@@ -1,6 +1,6 @@
 # typed: strong
 module Pecorino
-  VERSION = T.let("0.7.3", T.untyped)
+  VERSION = T.let("0.7.4", T.untyped)
 
   # Deletes stale leaky buckets and blocks which have expired. Run this method regularly to
   # avoid accumulating too many unused rows in your tables.
@@ -332,6 +332,8 @@ module Pecorino
     end
 
     class SqliteAdapter
+      include Pecorino::Adapters::ConnectionShim
+
       # sord omit - no YARD type given for "model_class", using untyped
       sig { params(model_class: T.untyped).void }
       def initialize(model_class); end
@@ -392,9 +394,31 @@ module Pecorino
       # sord omit - no YARD return type given, using untyped
       sig { params(active_record_schema: T.untyped).returns(T.untyped) }
       def create_tables(active_record_schema); end
+
+      # sord omit - no YARD type given for "*args", using untyped
+      # sord omit - no YARD return type given, using untyped
+      sig { params(args: T.untyped).returns(T.untyped) }
+      def sanitize_sql_array(*args); end
+
+      # sord omit - no YARD return type given, using untyped
+      sig { returns(T.untyped) }
+      def with_connection; end
+    end
+
+    module ConnectionShim
+      # sord omit - no YARD type given for "*args", using untyped
+      # sord omit - no YARD return type given, using untyped
+      sig { params(args: T.untyped).returns(T.untyped) }
+      def sanitize_sql_array(*args); end
+
+      # sord omit - no YARD return type given, using untyped
+      sig { returns(T.untyped) }
+      def with_connection; end
     end
 
     class PostgresAdapter
+      include Pecorino::Adapters::ConnectionShim
+
       # sord omit - no YARD type given for "model_class", using untyped
       sig { params(model_class: T.untyped).void }
       def initialize(model_class); end
@@ -455,6 +479,15 @@ module Pecorino
       # sord omit - no YARD return type given, using untyped
       sig { params(active_record_schema: T.untyped).returns(T.untyped) }
       def create_tables(active_record_schema); end
+
+      # sord omit - no YARD type given for "*args", using untyped
+      # sord omit - no YARD return type given, using untyped
+      sig { params(args: T.untyped).returns(T.untyped) }
+      def sanitize_sql_array(*args); end
+
+      # sord omit - no YARD return type given, using untyped
+      sig { returns(T.untyped) }
+      def with_connection; end
     end
   end
 

--- a/rbi/pecorino.rbs
+++ b/rbi/pecorino.rbs
@@ -281,6 +281,8 @@ module Pecorino
     end
 
     class SqliteAdapter
+      include Pecorino::Adapters::ConnectionShim
+
       # sord omit - no YARD type given for "model_class", using untyped
       def initialize: (untyped model_class) -> void
 
@@ -329,9 +331,27 @@ module Pecorino
       # sord omit - no YARD type given for "active_record_schema", using untyped
       # sord omit - no YARD return type given, using untyped
       def create_tables: (untyped active_record_schema) -> untyped
+
+      # sord omit - no YARD type given for "*args", using untyped
+      # sord omit - no YARD return type given, using untyped
+      def sanitize_sql_array: (*untyped args) -> untyped
+
+      # sord omit - no YARD return type given, using untyped
+      def with_connection: () -> untyped
+    end
+
+    module ConnectionShim
+      # sord omit - no YARD type given for "*args", using untyped
+      # sord omit - no YARD return type given, using untyped
+      def sanitize_sql_array: (*untyped args) -> untyped
+
+      # sord omit - no YARD return type given, using untyped
+      def with_connection: () -> untyped
     end
 
     class PostgresAdapter
+      include Pecorino::Adapters::ConnectionShim
+
       # sord omit - no YARD type given for "model_class", using untyped
       def initialize: (untyped model_class) -> void
 
@@ -380,6 +400,13 @@ module Pecorino
       # sord omit - no YARD type given for "active_record_schema", using untyped
       # sord omit - no YARD return type given, using untyped
       def create_tables: (untyped active_record_schema) -> untyped
+
+      # sord omit - no YARD type given for "*args", using untyped
+      # sord omit - no YARD return type given, using untyped
+      def sanitize_sql_array: (*untyped args) -> untyped
+
+      # sord omit - no YARD return type given, using untyped
+      def with_connection: () -> untyped
     end
   end
 

--- a/test/adapters/adapter_test_methods.rb
+++ b/test/adapters/adapter_test_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The module contains the conformance tests for a storage adapter for Pecorino. A well-behaved adapter
 # should pass all of these tests. When creating a new adapter include this module in your test case
 # and overload the `create_adapter` method

--- a/test/adapters/memory_adapter_test.rb
+++ b/test/adapters/memory_adapter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require_relative "adapter_test_methods"
 

--- a/test/adapters/postgres_adapter_test.rb
+++ b/test/adapters/postgres_adapter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require_relative "adapter_test_methods"
 

--- a/test/adapters/redis_adapter_test.rb
+++ b/test/adapters/redis_adapter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require_relative "adapter_test_methods"
 

--- a/test/adapters/sqlite_adapter_test.rb
+++ b/test/adapters/sqlite_adapter_test.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require_relative "adapter_test_methods"
+require "fileutils"
 
 class SqliteAdapterTest < ActiveSupport::TestCase
   include AdapterTestMethods
@@ -11,20 +14,34 @@ class SqliteAdapterTest < ActiveSupport::TestCase
     ActiveRecord::Migration.verbose = false
     ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: db_filename)
 
+    # The adapter has to be in a variable as the schema definition is scoped to the migrator, not self
+    retained_adapter = create_adapter # the schema define block is run via instance_exec so it does not retain scope
     ActiveRecord::Schema.define(version: 1) do |via_definer|
-      Pecorino.create_tables(via_definer)
+      retained_adapter.create_tables(via_definer)
     end
   end
 
   def drop_sqlite_db
-    ActiveRecord::Base.connection.close
-    FileUtils.rm_rf(db_filename)
-    FileUtils.rm_rf(db_filename + "-wal")
-    FileUtils.rm_rf(db_filename + "-shm")
+    # Close all connections before deleting the database file
+    if ActiveRecord::Base.connected?
+      ActiveRecord::Base.connection_pool.disconnect!
+    end
+    ActiveRecord::Base.remove_connection if ActiveRecord::Base.connection_handler
+
+    # Delete database files if they exist
+    FileUtils.rm_rf(db_filename) if File.exist?(db_filename)
+    FileUtils.rm_rf(db_filename + "-wal") if File.exist?(db_filename + "-wal")
+    FileUtils.rm_rf(db_filename + "-shm") if File.exist?(db_filename + "-shm")
+  rescue
+    # Ignore errors during teardown - file might already be deleted or locked
   end
 
   def db_filename
-    "pecorino_tests_%s.sqlite3" % Random.new(Minitest.seed).hex(4)
+    @db_filename ||= begin
+      tmp_dir = File.expand_path(File.join(__dir__, "..", "..", "tmp"))
+      FileUtils.mkdir_p(tmp_dir) unless File.directory?(tmp_dir)
+      File.join(tmp_dir, "pecorino_tests_%s_%s.sqlite3" % [Random.new(Minitest.seed).hex(4), object_id])
+    end
   end
 
   def create_adapter

--- a/test/block_test.rb
+++ b/test/block_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "test_helper"
+require_relative "test_helper"
 require "base64"
 
 class BlockTest < ActiveSupport::TestCase
@@ -11,16 +11,17 @@ class BlockTest < ActiveSupport::TestCase
   test "sets a block" do
     k = Base64.strict_encode64(Random.bytes(4))
     assert_nil Pecorino::Block.blocked_until(key: k, adapter: @adapter)
-    assert Pecorino::Block.set!(key: k, block_for: 30.minutes, adapter: @adapter)
+    assert Pecorino::Block.set!(key: k, block_for: 30 * 60, adapter: @adapter)
 
     blocked_until = Pecorino::Block.blocked_until(key: k, adapter: @adapter)
-    assert_in_delta Time.now + 30.minutes, blocked_until, 10
+    assert_in_delta Time.now + (30 * 60), blocked_until, 10
   end
 
   test "does not return a block which has lapsed" do
     k = Base64.strict_encode64(Random.bytes(4))
+
     assert_nil Pecorino::Block.blocked_until(key: k, adapter: @adapter)
-    Pecorino::Block.set!(key: k, block_for: -30.minutes, adapter: @adapter)
+    Pecorino::Block.set!(key: k, block_for: -30 * 60, adapter: @adapter)
     blocked_until = Pecorino::Block.blocked_until(key: k, adapter: @adapter)
     assert_nil blocked_until
   end

--- a/test/leaky_bucket_concurrency_postgres_test.rb
+++ b/test/leaky_bucket_concurrency_postgres_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "leaky_bucket_concurrency_test_shared"
+
+require "fileutils"
+require "csv"
+
+class PecorinoLeakyBucketConcurrencyPostgresTest < ActiveSupport::TestCase
+  include LeakyBucketConcurrencyTestShared
+
+  SEED_DB_NAME = -> { "pecorino_tests_%s" % Random.new(Minitest.seed).hex(4) }
+
+  def self.establish_connection(**options)
+    ActiveRecord::Base.establish_connection(
+      adapter: "postgresql",
+      connect_timeout: 2,
+      **options
+    )
+  end
+
+  def setup
+    # Clean up any previous test artifacts
+    @test_dir = File.join(Dir.tmpdir, "pecorino_test_#{Process.pid}")
+    FileUtils.rm_rf(@test_dir)
+    FileUtils.mkdir_p(@test_dir)
+
+    # Use real PostgreSQL adapter (not test adapter) to test actual race conditions
+    # The test adapter uses in-memory state which won't show the race condition
+    # Ensure we have a PostgreSQL connection set up
+    @db_name = SEED_DB_NAME.call
+    create_postgres_database_if_none
+  end
+
+  def teardown
+    FileUtils.rm_rf(@test_dir) if File.exist?(@test_dir)
+    # Clean up Pecorino buckets
+    ActiveRecord::Base.connection.execute("DELETE FROM pecorino_leaky_buckets WHERE key = 'concurrency_test_bucket'")
+  end
+
+  def create_postgres_database_if_none
+    self.class.establish_connection(encoding: "unicode", database: @db_name)
+    adapter = Pecorino::Adapters::PostgresAdapter.new(ActiveRecord::Base)
+    ActiveRecord::Base.connection_pool.with_connection { |connection| connection.execute("SELECT 1 FROM pecorino_leaky_buckets") }
+  rescue ActiveRecord::NoDatabaseError, ActiveRecord::ConnectionNotEstablished
+    create_postgres_database
+    retry
+  rescue ActiveRecord::StatementInvalid
+    adapter = Pecorino::Adapters::PostgresAdapter.new(ActiveRecord::Base)
+    ActiveRecord::Schema.define(version: 1) do |via_definer|
+      adapter.create_tables(via_definer)
+    end
+    retry
+  end
+
+  def create_postgres_database
+    ActiveRecord::Migration.verbose = false
+    self.class.establish_connection(database: "postgres")
+    ActiveRecord::Base.connection_pool.with_connection { |connection| connection.create_database(@db_name, charset: :unicode) }
+    ActiveRecord::Base.connection.close
+    self.class.establish_connection(encoding: "unicode", database: @db_name)
+  end
+
+  test "concurrent fillup_conditionally calls should not exceed bucket capacity" do
+    # This test documents a bug in Pecorino's fillup_conditionally implementation.
+    # Currently it fails due to a race condition where concurrent processes can all
+    # read the same bucket state before any of them update it, allowing total tokens
+    # to exceed capacity. Once Pecorino is fixed, this test should pass.
+
+    db_name = @db_name
+    run_concurrency_test(
+      adapter: Pecorino.adapter,
+      setup_forked_process: -> {
+        # Reconnect to database in forked process
+        # Use the same database name as the parent process
+        self.class.establish_connection(encoding: "unicode", database: db_name)
+        Pecorino.adapter
+      }
+    )
+  end
+
+  private
+
+  def cleanup_forked_process
+    # Close database connection in forked process
+    ActiveRecord::Base.connection.close
+  end
+end

--- a/test/leaky_bucket_concurrency_redis_test.rb
+++ b/test/leaky_bucket_concurrency_redis_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "leaky_bucket_concurrency_test_shared"
+
+require "fileutils"
+require "csv"
+require "redis"
+require "active_support/core_ext/numeric/time"
+
+class PecorinoLeakyBucketConcurrencyRedisTest < ActiveSupport::TestCase
+  include LeakyBucketConcurrencyTestShared
+
+  def setup
+    # Clean up any previous test artifacts
+    @test_dir = File.join(Dir.tmpdir, "pecorino_test_#{Process.pid}")
+    FileUtils.rm_rf(@test_dir)
+    FileUtils.mkdir_p(@test_dir)
+
+    # Use real Redis adapter (not test adapter) to test actual race conditions
+    # The test adapter uses in-memory state which won't show the race condition
+    # Ensure we have a Redis connection set up
+    @key_prefix = "pecorino-test-#{Random.new(Minitest.seed).hex(4)}"
+    @redis = Redis.new
+    @adapter = Pecorino::Adapters::RedisAdapter.new(@redis, key_prefix: @key_prefix)
+
+    # Set Pecorino to use Redis adapter
+    Pecorino.adapter = @adapter
+  end
+
+  def teardown
+    FileUtils.rm_rf(@test_dir) if File.exist?(@test_dir)
+    # Clean up Redis keys
+    if @redis
+      keys = @redis.keys("#{@key_prefix}:*")
+      @redis.del(keys) if keys.any?
+    end
+  rescue
+    # Ignore errors during teardown
+  end
+
+  test "concurrent fillup_conditionally calls should not exceed bucket capacity" do
+    # This test documents a bug in Pecorino's fillup_conditionally implementation.
+    # Currently it fails due to a race condition where concurrent processes can all
+    # read the same bucket state before any of them update it, allowing total tokens
+    # to exceed capacity. Once Pecorino is fixed, this test should pass.
+
+    key_prefix = @key_prefix
+    run_concurrency_test(
+      adapter: @adapter,
+      setup_forked_process: -> {
+        # Reconnect to Redis in forked process
+        # Use the same key_prefix as the parent process
+        redis = Redis.new
+        adapter = Pecorino::Adapters::RedisAdapter.new(redis, key_prefix: key_prefix)
+        adapter
+      }
+    )
+  end
+
+  private
+
+  def cleanup_forked_process
+    # Close Redis connection in forked process
+    # Note: Redis connection is created in setup_forked_process, so we need to track it
+    # For simplicity, we'll just ensure cleanup happens
+  end
+end

--- a/test/leaky_bucket_concurrency_sqlite_test.rb
+++ b/test/leaky_bucket_concurrency_sqlite_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "leaky_bucket_concurrency_test_shared"
+
+require "fileutils"
+require "csv"
+
+class PecorinoLeakyBucketConcurrencySqliteTest < ActiveSupport::TestCase
+  include LeakyBucketConcurrencyTestShared
+
+  def setup
+    # Clean up any previous test artifacts
+    @test_dir = File.join(Dir.tmpdir, "pecorino_test_#{Process.pid}")
+    FileUtils.rm_rf(@test_dir)
+    FileUtils.mkdir_p(@test_dir)
+
+    # Use real SQLite3 adapter (not test adapter) to test actual race conditions
+    # The test adapter uses in-memory state which won't show the race condition
+    # Ensure we have a SQLite3 connection set up
+    @db_filename = File.join(@test_dir, "pecorino_tests_#{Random.new(Minitest.seed).hex(4)}.sqlite3")
+    create_sqlite_database_if_none
+  end
+
+  def teardown
+    FileUtils.rm_rf(@test_dir) if File.exist?(@test_dir)
+    # Clean up Pecorino buckets
+    ActiveRecord::Base.connection.execute("DELETE FROM pecorino_leaky_buckets WHERE key = 'concurrency_test_bucket'") if ActiveRecord::Base.connected?
+  rescue
+    # Ignore errors during teardown
+  end
+
+  def create_sqlite_database_if_none
+    ActiveRecord::Migration.verbose = false
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: @db_filename)
+    adapter = Pecorino::Adapters::SqliteAdapter.new(ActiveRecord::Base)
+    ActiveRecord::Base.connection_pool.with_connection { |connection| connection.execute("SELECT 1 FROM pecorino_leaky_buckets") }
+  rescue ActiveRecord::StatementInvalid
+    adapter = Pecorino::Adapters::SqliteAdapter.new(ActiveRecord::Base)
+    ActiveRecord::Schema.define(version: 1) do |via_definer|
+      adapter.create_tables(via_definer)
+    end
+    retry
+  end
+
+  def self.establish_connection(**options)
+    ActiveRecord::Base.establish_connection(
+      adapter: "sqlite3",
+      **options
+    )
+  end
+
+  test "concurrent fillup_conditionally calls should not exceed bucket capacity" do
+    # This test documents a bug in Pecorino's fillup_conditionally implementation.
+    # Currently it fails due to a race condition where concurrent processes can all
+    # read the same bucket state before any of them update it, allowing total tokens
+    # to exceed capacity. Once Pecorino is fixed, this test should pass.
+
+    db_filename = @db_filename
+    run_concurrency_test(
+      adapter: Pecorino.adapter,
+      setup_forked_process: -> {
+        # Reconnect to database in forked process
+        # Use the same database filename as the parent process
+        self.class.establish_connection(database: db_filename)
+        Pecorino.adapter
+      }
+    )
+  end
+
+  private
+
+  def cleanup_forked_process
+    # Close database connection in forked process
+    ActiveRecord::Base.connection.close
+  end
+end

--- a/test/leaky_bucket_concurrency_test.rb
+++ b/test/leaky_bucket_concurrency_test.rb
@@ -80,9 +80,6 @@ class PecorinoLeakyBucketConcurrencyTest < ActiveSupport::TestCase
     over_time = 3.seconds
     tokens_per_call = 5
 
-    # Calculate expected max calls
-    max_calls = bucket_capacity / tokens_per_call # 100 calls
-
     # We'll try to make more calls than allowed, concurrently
     # fillup_conditionally should reject calls that would exceed capacity
     num_processes = 5
@@ -209,8 +206,6 @@ class PecorinoLeakyBucketConcurrencyTest < ActiveSupport::TestCase
 
     accepted_calls = calls.select { |c| c[:status] == "accepted" }
 
-    rejected_calls = calls.select { |c| c[:status] == "rejected" }
-
     # Epsilon for floating point comparisons (accounting for precision and timing)
     # We use a small tolerance to account for floating point arithmetic precision,
     # database timestamp precision, and timing variations in concurrent operations.
@@ -221,25 +216,6 @@ class PecorinoLeakyBucketConcurrencyTest < ActiveSupport::TestCase
     # Use epsilon tolerance to account for floating point precision
     violations = accepted_calls.select { |c| c[:level_after] && c[:level_after] > bucket_capacity + epsilon }
 
-    # Also check if level_before + tokens_per_call would exceed capacity
-    # This catches cases where multiple transactions saw the same level_before
-    # Use epsilon tolerance for floating point comparisons
-    would_exceed_violations = accepted_calls.select do |c|
-      if c[:level_before] && c[:level_after]
-        would_exceed = (c[:level_before] + tokens_per_call) > bucket_capacity + epsilon
-        # But the actual level_after is less than capacity (due to leakage or rejection)
-        # Use epsilon tolerance here too
-        would_exceed && c[:level_after] <= bucket_capacity + epsilon
-      else
-        false
-      end
-    end
-
-    # Calculate actual tokens added by tracking level changes
-    # Note: This is approximate since tokens leak over time
-    # But we can verify the level never exceeds capacity
-    total_tokens_added = accepted_calls.count * tokens_per_call
-
     # Check the final bucket level
     final_bucket = Pecorino::LeakyBucket.new(
       key: "concurrency_test_bucket",
@@ -248,114 +224,6 @@ class PecorinoLeakyBucketConcurrencyTest < ActiveSupport::TestCase
       adapter: Pecorino.adapter
     )
     final_state = final_bucket.state
-
-    puts "\n=== Test Results ==="
-    puts "Total accepted calls: #{accepted_calls.count}"
-    puts "Total rejected calls: #{rejected_calls.count}"
-    puts "Total tokens added (estimated): #{total_tokens_added} tokens"
-    puts "Bucket capacity: #{bucket_capacity} tokens"
-    puts "Expected max calls: #{max_calls}"
-    puts "Final bucket level: #{final_state.level.round(2)}"
-    puts "Final bucket full?: #{final_state.full?}"
-
-    if violations.any?
-      puts "\n=== VIOLATIONS DETECTED ==="
-      puts "Found #{violations.count} accepted calls that resulted in level > capacity:"
-      violations.first(10).each do |v|
-        puts "  Process #{v[:process_id]}, Call #{v[:call_id]}: level_before=#{v[:level_before]&.round(4)}, level_after=#{v[:level_after].round(4)} (capacity = #{bucket_capacity})"
-      end
-      puts "  ... (showing first 10)" if violations.count > 10
-    end
-
-    if would_exceed_violations.any?
-      puts "\n=== CALLS WHERE level_before + tokens WOULD EXCEED CAPACITY ==="
-      puts "Found #{would_exceed_violations.count} calls where queried level_before + tokens would exceed capacity"
-      puts "Note: These may be valid if tokens leaked between query and fillup execution"
-      would_exceed_violations.first(10).each do |v|
-        expected_level = v[:level_before] + tokens_per_call
-        actual_added = v[:level_after] - v[:level_before]
-        leaked = tokens_per_call - actual_added
-        puts "  Process #{v[:process_id]}, Call #{v[:call_id]}:"
-        puts "    Queried level_before: #{v[:level_before].round(4)}"
-        puts "    Expected if no leak: #{expected_level.round(4)} (would exceed!)"
-        puts "    Actual level_after: #{v[:level_after].round(4)} (valid: < #{bucket_capacity})"
-        puts "    Actual tokens added: #{actual_added.round(4)} (leaked: #{leaked.round(4)} during transaction)"
-      end
-      puts "  ... (showing first 10)" if would_exceed_violations.count > 10
-    end
-
-    # Show level progression for first few accepted calls
-    if accepted_calls.any?
-      puts "\n=== Level Progression (first 20 accepted calls) ==="
-      accepted_calls.first(20).each_with_index do |c, idx|
-        puts "  #{idx + 1}. Level before: #{c[:level_before] ? c[:level_before].round(4) : "N/A"}, after: #{c[:level_after] ? c[:level_after].round(4) : "N/A"}"
-      end
-
-      # Show calls near capacity
-      near_capacity = accepted_calls.select { |c| c[:level_after] && c[:level_after] > bucket_capacity * 0.9 }
-      if near_capacity.any?
-        puts "\n=== Calls Near Capacity (>90%) ==="
-        near_capacity.first(20).each do |c|
-          puts "  Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before]&.round(4)}, level_after=#{c[:level_after].round(4)} (#{(c[:level_after] / bucket_capacity * 100).round(2)}% of capacity)"
-        end
-      end
-
-      # Show the level before vs after for last 20 accepted calls
-      puts "\n=== Level Before vs After (last 20 accepted calls) ==="
-      accepted_calls.last(20).each do |c|
-        if c[:level_before] && c[:level_after]
-          would_exceed = (c[:level_before] + tokens_per_call) > bucket_capacity
-          margin = bucket_capacity - c[:level_before]
-          actual_added = c[:level_after] - c[:level_before]
-          puts "  Level before: #{c[:level_before].round(4)}, after: #{c[:level_after].round(4)}, margin: #{margin.round(4)}, would_exceed: #{would_exceed}, actual_added: #{actual_added.round(4)}"
-        end
-      end
-
-      # Find calls that were accepted when there was very little margin
-      # These are suspicious - multiple concurrent transactions might have all seen
-      # the same low margin and all accepted
-      # Use epsilon tolerance for floating point comparison
-      low_margin_calls = accepted_calls.select do |c|
-        if c[:level_before]
-          margin = bucket_capacity - c[:level_before]
-          margin < tokens_per_call * 2 + epsilon # Less than 2x tokens_per_call margin (with epsilon tolerance)
-        else
-          false
-        end
-      end
-
-      if low_margin_calls.any?
-        puts "\n=== Low Margin Calls (potential race condition) ==="
-        puts "Found #{low_margin_calls.count} calls accepted with margin < #{tokens_per_call * 2}"
-        low_margin_calls.each do |c|
-          margin = bucket_capacity - c[:level_before]
-          time_offset = c[:timestamp] - calls.first[:timestamp]
-          actual_added = c[:level_after] - c[:level_before]
-          puts "  Time: #{time_offset.round(4)}s, Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before].round(4)}, margin=#{margin.round(4)}, level_after=#{c[:level_after].round(4)}, actual_added=#{actual_added.round(4)}"
-        end
-
-        # Check if any low-margin calls happened at nearly the same time
-        if low_margin_calls.count > 1
-          timestamps = low_margin_calls.map { |c| c[:timestamp] }.sort
-          time_diffs = timestamps.each_cons(2).map { |a, b| b - a }
-          concurrent_pairs = time_diffs.count { |diff| diff < 0.01 } # Within 10ms
-          puts "  Concurrent low-margin calls (within 10ms): #{concurrent_pairs} pairs"
-
-          # Group by time windows to find concurrent calls
-          time_windows = low_margin_calls.group_by { |c| (c[:timestamp] * 100).floor / 100.0 } # Group by 10ms windows
-          concurrent_groups = time_windows.select { |_time, calls| calls.count > 1 }
-          if concurrent_groups.any?
-            puts "  Concurrent groups:"
-            concurrent_groups.each do |time_window, group_calls|
-              puts "    Time window #{time_window.round(4)}s: #{group_calls.count} calls"
-              group_calls.each do |c|
-                puts "      Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before].round(4)}, level_after=#{c[:level_after].round(4)}"
-              end
-            end
-          end
-        end
-      end
-    end
 
     # KEY ASSERTION: fillup_conditionally should NEVER result in a level exceeding capacity
     # This is the most important check - the bucket level after ANY accepted fillup
@@ -431,7 +299,6 @@ class PecorinoLeakyBucketConcurrencyTest < ActiveSupport::TestCase
     if accepted_calls.any?
       timestamps = accepted_calls.map { |c| c[:timestamp] }
       time_span = timestamps.max - timestamps.min
-      puts "Time span of accepted calls: #{time_span.round(2)} seconds"
 
       # Calls should complete within a reasonable time (not take minutes)
       assert_operator time_span, :<, 30.0, "Calls should happen concurrently, not sequentially"

--- a/test/leaky_bucket_concurrency_test.rb
+++ b/test/leaky_bucket_concurrency_test.rb
@@ -1,0 +1,440 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+require "fileutils"
+require "csv"
+
+class PecorinoLeakyBucketConcurrencyTest < ActiveSupport::TestCase
+  SEED_DB_NAME = -> { "pecorino_tests_%s" % Random.new(Minitest.seed).hex(4) }
+
+  def self.establish_connection(**options)
+    ActiveRecord::Base.establish_connection(
+      adapter: "postgresql",
+      connect_timeout: 2,
+      **options
+    )
+  end
+
+  def setup
+    # Clean up any previous test artifacts
+    @test_dir = File.join(Dir.tmpdir, "pecorino_test_#{Process.pid}")
+    FileUtils.rm_rf(@test_dir)
+    FileUtils.mkdir_p(@test_dir)
+
+    # Use real PostgreSQL adapter (not test adapter) to test actual race conditions
+    # The test adapter uses in-memory state which won't show the race condition
+    # Ensure we have a PostgreSQL connection set up
+    @db_name = SEED_DB_NAME.call
+    create_postgres_database_if_none
+  end
+
+  def teardown
+    FileUtils.rm_rf(@test_dir) if File.exist?(@test_dir)
+    # Clean up Pecorino buckets
+    ActiveRecord::Base.connection.execute("DELETE FROM pecorino_leaky_buckets WHERE key = 'concurrency_test_bucket'")
+  end
+
+  def copy_csv_on_failure(log_file)
+    if File.exist?(log_file)
+      timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+      tmp_dir = File.join(__dir__, "..", "tmp")
+      FileUtils.mkdir_p(tmp_dir)
+      dest_file = File.join(tmp_dir, "concurrency_test_failure_#{timestamp}.csv")
+      FileUtils.cp(log_file, dest_file)
+      puts "\n=== CSV file copied to #{dest_file} for analysis ==="
+    end
+  end
+
+  def create_postgres_database_if_none
+    self.class.establish_connection(encoding: "unicode", database: @db_name)
+    adapter = Pecorino::Adapters::PostgresAdapter.new(ActiveRecord::Base)
+    ActiveRecord::Base.connection_pool.with_connection { |connection| connection.execute("SELECT 1 FROM pecorino_leaky_buckets") }
+  rescue ActiveRecord::NoDatabaseError, ActiveRecord::ConnectionNotEstablished
+    create_postgres_database
+    retry
+  rescue ActiveRecord::StatementInvalid
+    adapter = Pecorino::Adapters::PostgresAdapter.new(ActiveRecord::Base)
+    ActiveRecord::Schema.define(version: 1) do |via_definer|
+      adapter.create_tables(via_definer)
+    end
+    retry
+  end
+
+  def create_postgres_database
+    ActiveRecord::Migration.verbose = false
+    self.class.establish_connection(database: "postgres")
+    ActiveRecord::Base.connection_pool.with_connection { |connection| connection.create_database(@db_name, charset: :unicode) }
+    ActiveRecord::Base.connection.close
+    self.class.establish_connection(encoding: "unicode", database: @db_name)
+  end
+
+  test "concurrent fillup_conditionally calls should not exceed bucket capacity" do
+    # This test documents a bug in Pecorino's fillup_conditionally implementation.
+    # Currently it fails due to a race condition where concurrent processes can all
+    # read the same bucket state before any of them update it, allowing total tokens
+    # to exceed capacity. Once Pecorino is fixed, this test should pass.
+
+    # Configuration for testing
+    bucket_capacity = 500 # Small capacity for testing
+    over_time = 3.seconds
+    tokens_per_call = 5
+
+    # Calculate expected max calls
+    max_calls = bucket_capacity / tokens_per_call # 100 calls
+
+    # We'll try to make more calls than allowed, concurrently
+    # fillup_conditionally should reject calls that would exceed capacity
+    num_processes = 5
+    calls_per_process = 200 # Total: 1000 calls attempted, but only 100 should succeed
+
+    # Create a log file to track calls across processes
+    log_file = File.join(@test_dir, "calls.csv")
+    # Write CSV header
+    CSV.open(log_file, "w") do |csv|
+      csv << ["monotonic_time", "process_id", "call_id", "status", "level_before", "level_after"]
+    end
+
+    # Capture database name for forked processes
+    db_name = @db_name
+
+    # Fork multiple processes that will make concurrent requests
+    pids = []
+
+    num_processes.times do |process_id|
+      pid = fork do
+        # Reconnect to database in forked process
+        # Use the same database name as the parent process
+        self.class.establish_connection(encoding: "unicode", database: db_name)
+
+        # Each process creates its own bucket instance
+        # They all share the same database key, which is where the race condition occurs
+        bucket = Pecorino::LeakyBucket.new(
+          key: "concurrency_test_bucket",
+          capacity: bucket_capacity,
+          over_time: over_time,
+          adapter: Pecorino.adapter
+        )
+
+        # Make many calls concurrently
+        calls_per_process.times do |call_id|
+          # Query the bucket state BEFORE the fillup to see what level it was at
+          state_before = bucket.state
+
+          # Try to add tokens conditionally
+          result = bucket.fillup_conditionally(tokens_per_call)
+
+          # Log the result with state before and after using CSV format
+          monotonic_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          row = [
+            monotonic_time,
+            process_id,
+            call_id,
+            result.accepted? ? "accepted" : "rejected",
+            state_before.level,
+            result.level
+          ]
+          File.open(log_file, "a") do |f|
+            f.flock(File::LOCK_EX)
+            f << CSV.generate_line(row)
+            f.flock(File::LOCK_UN)
+          end
+        rescue
+          # Log errors
+          monotonic_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          row = [
+            monotonic_time,
+            process_id,
+            call_id,
+            "error",
+            nil,
+            nil
+          ]
+          File.open(log_file, "a") do |f|
+            f.flock(File::LOCK_EX)
+            f << CSV.generate_line(row)
+            f.flock(File::LOCK_UN)
+          end
+        end
+
+        # Close database connection in forked process
+        ActiveRecord::Base.connection.close
+      end
+
+      pids << pid
+    end
+
+    # Wait for all processes to complete
+    pids.each do |pid|
+      Process.wait(pid)
+    end
+
+    # Read and analyze the log file using CSV
+    calls = []
+
+    CSV.foreach(log_file, headers: true, header_converters: :symbol) do |row|
+      monotonic_time = row[:monotonic_time].to_f
+      process_id = row[:process_id].to_i
+      call_id = row[:call_id].to_i
+      status = row[:status]
+
+      if status == "error"
+        calls << {
+          timestamp: monotonic_time,
+          process_id: process_id,
+          call_id: call_id,
+          status: status,
+          level_before: nil,
+          level_after: nil,
+          level_or_error: nil
+        }
+      else
+        level_before = row[:level_before]&.to_f
+        level_after = row[:level_after]&.to_f
+
+        calls << {
+          timestamp: monotonic_time,
+          process_id: process_id,
+          call_id: call_id,
+          status: status,
+          level_before: level_before,
+          level_after: level_after,
+          level_or_error: level_after
+        }
+      end
+    end
+
+    # Sort calls by timestamp to see the progression
+    calls.sort_by! { |c| c[:timestamp] }
+
+    accepted_calls = calls.select { |c| c[:status] == "accepted" }
+
+    rejected_calls = calls.select { |c| c[:status] == "rejected" }
+
+    # Epsilon for floating point comparisons (accounting for precision and timing)
+    # We use a small tolerance to account for floating point arithmetic precision,
+    # database timestamp precision, and timing variations in concurrent operations.
+    # This prevents false positives from floating point rounding errors.
+    epsilon = 0.01
+
+    # Check that NO accepted call resulted in a level exceeding capacity
+    # Use epsilon tolerance to account for floating point precision
+    violations = accepted_calls.select { |c| c[:level_after] && c[:level_after] > bucket_capacity + epsilon }
+
+    # Also check if level_before + tokens_per_call would exceed capacity
+    # This catches cases where multiple transactions saw the same level_before
+    # Use epsilon tolerance for floating point comparisons
+    would_exceed_violations = accepted_calls.select do |c|
+      if c[:level_before] && c[:level_after]
+        would_exceed = (c[:level_before] + tokens_per_call) > bucket_capacity + epsilon
+        # But the actual level_after is less than capacity (due to leakage or rejection)
+        # Use epsilon tolerance here too
+        would_exceed && c[:level_after] <= bucket_capacity + epsilon
+      else
+        false
+      end
+    end
+
+    # Calculate actual tokens added by tracking level changes
+    # Note: This is approximate since tokens leak over time
+    # But we can verify the level never exceeds capacity
+    total_tokens_added = accepted_calls.count * tokens_per_call
+
+    # Check the final bucket level
+    final_bucket = Pecorino::LeakyBucket.new(
+      key: "concurrency_test_bucket",
+      capacity: bucket_capacity,
+      over_time: over_time,
+      adapter: Pecorino.adapter
+    )
+    final_state = final_bucket.state
+
+    puts "\n=== Test Results ==="
+    puts "Total accepted calls: #{accepted_calls.count}"
+    puts "Total rejected calls: #{rejected_calls.count}"
+    puts "Total tokens added (estimated): #{total_tokens_added} tokens"
+    puts "Bucket capacity: #{bucket_capacity} tokens"
+    puts "Expected max calls: #{max_calls}"
+    puts "Final bucket level: #{final_state.level.round(2)}"
+    puts "Final bucket full?: #{final_state.full?}"
+
+    if violations.any?
+      puts "\n=== VIOLATIONS DETECTED ==="
+      puts "Found #{violations.count} accepted calls that resulted in level > capacity:"
+      violations.first(10).each do |v|
+        puts "  Process #{v[:process_id]}, Call #{v[:call_id]}: level_before=#{v[:level_before]&.round(4)}, level_after=#{v[:level_after].round(4)} (capacity = #{bucket_capacity})"
+      end
+      puts "  ... (showing first 10)" if violations.count > 10
+    end
+
+    if would_exceed_violations.any?
+      puts "\n=== CALLS WHERE level_before + tokens WOULD EXCEED CAPACITY ==="
+      puts "Found #{would_exceed_violations.count} calls where queried level_before + tokens would exceed capacity"
+      puts "Note: These may be valid if tokens leaked between query and fillup execution"
+      would_exceed_violations.first(10).each do |v|
+        expected_level = v[:level_before] + tokens_per_call
+        actual_added = v[:level_after] - v[:level_before]
+        leaked = tokens_per_call - actual_added
+        puts "  Process #{v[:process_id]}, Call #{v[:call_id]}:"
+        puts "    Queried level_before: #{v[:level_before].round(4)}"
+        puts "    Expected if no leak: #{expected_level.round(4)} (would exceed!)"
+        puts "    Actual level_after: #{v[:level_after].round(4)} (valid: < #{bucket_capacity})"
+        puts "    Actual tokens added: #{actual_added.round(4)} (leaked: #{leaked.round(4)} during transaction)"
+      end
+      puts "  ... (showing first 10)" if would_exceed_violations.count > 10
+    end
+
+    # Show level progression for first few accepted calls
+    if accepted_calls.any?
+      puts "\n=== Level Progression (first 20 accepted calls) ==="
+      accepted_calls.first(20).each_with_index do |c, idx|
+        puts "  #{idx + 1}. Level before: #{c[:level_before] ? c[:level_before].round(4) : "N/A"}, after: #{c[:level_after] ? c[:level_after].round(4) : "N/A"}"
+      end
+
+      # Show calls near capacity
+      near_capacity = accepted_calls.select { |c| c[:level_after] && c[:level_after] > bucket_capacity * 0.9 }
+      if near_capacity.any?
+        puts "\n=== Calls Near Capacity (>90%) ==="
+        near_capacity.first(20).each do |c|
+          puts "  Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before]&.round(4)}, level_after=#{c[:level_after].round(4)} (#{(c[:level_after] / bucket_capacity * 100).round(2)}% of capacity)"
+        end
+      end
+
+      # Show the level before vs after for last 20 accepted calls
+      puts "\n=== Level Before vs After (last 20 accepted calls) ==="
+      accepted_calls.last(20).each do |c|
+        if c[:level_before] && c[:level_after]
+          would_exceed = (c[:level_before] + tokens_per_call) > bucket_capacity
+          margin = bucket_capacity - c[:level_before]
+          actual_added = c[:level_after] - c[:level_before]
+          puts "  Level before: #{c[:level_before].round(4)}, after: #{c[:level_after].round(4)}, margin: #{margin.round(4)}, would_exceed: #{would_exceed}, actual_added: #{actual_added.round(4)}"
+        end
+      end
+
+      # Find calls that were accepted when there was very little margin
+      # These are suspicious - multiple concurrent transactions might have all seen
+      # the same low margin and all accepted
+      # Use epsilon tolerance for floating point comparison
+      low_margin_calls = accepted_calls.select do |c|
+        if c[:level_before]
+          margin = bucket_capacity - c[:level_before]
+          margin < tokens_per_call * 2 + epsilon # Less than 2x tokens_per_call margin (with epsilon tolerance)
+        else
+          false
+        end
+      end
+
+      if low_margin_calls.any?
+        puts "\n=== Low Margin Calls (potential race condition) ==="
+        puts "Found #{low_margin_calls.count} calls accepted with margin < #{tokens_per_call * 2}"
+        low_margin_calls.each do |c|
+          margin = bucket_capacity - c[:level_before]
+          time_offset = c[:timestamp] - calls.first[:timestamp]
+          actual_added = c[:level_after] - c[:level_before]
+          puts "  Time: #{time_offset.round(4)}s, Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before].round(4)}, margin=#{margin.round(4)}, level_after=#{c[:level_after].round(4)}, actual_added=#{actual_added.round(4)}"
+        end
+
+        # Check if any low-margin calls happened at nearly the same time
+        if low_margin_calls.count > 1
+          timestamps = low_margin_calls.map { |c| c[:timestamp] }.sort
+          time_diffs = timestamps.each_cons(2).map { |a, b| b - a }
+          concurrent_pairs = time_diffs.count { |diff| diff < 0.01 } # Within 10ms
+          puts "  Concurrent low-margin calls (within 10ms): #{concurrent_pairs} pairs"
+
+          # Group by time windows to find concurrent calls
+          time_windows = low_margin_calls.group_by { |c| (c[:timestamp] * 100).floor / 100.0 } # Group by 10ms windows
+          concurrent_groups = time_windows.select { |_time, calls| calls.count > 1 }
+          if concurrent_groups.any?
+            puts "  Concurrent groups:"
+            concurrent_groups.each do |time_window, group_calls|
+              puts "    Time window #{time_window.round(4)}s: #{group_calls.count} calls"
+              group_calls.each do |c|
+                puts "      Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before].round(4)}, level_after=#{c[:level_after].round(4)}"
+              end
+            end
+          end
+        end
+      end
+    end
+
+    # KEY ASSERTION: fillup_conditionally should NEVER result in a level exceeding capacity
+    # This is the most important check - the bucket level after ANY accepted fillup
+    # must never exceed the capacity, regardless of concurrency.
+    begin
+      assert_empty violations,
+        "fillup_conditionally should NEVER allow the bucket level to exceed capacity. " \
+        "Found #{violations.count} violations where level_after > #{bucket_capacity} + #{epsilon} (epsilon tolerance). " \
+        "This indicates a race condition in Pecorino's fillup_conditionally implementation."
+    rescue Minitest::Assertion
+      # On failure, copy CSV to tmp/ directory for analysis
+      if File.exist?(log_file)
+        timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+        tmp_dir = File.join(__dir__, "..", "tmp")
+        FileUtils.mkdir_p(tmp_dir)
+        dest_file = File.join(tmp_dir, "concurrency_test_failure_#{timestamp}.csv")
+        FileUtils.cp(log_file, dest_file)
+        puts "\n=== CSV file copied to #{dest_file} for analysis ==="
+      end
+      raise
+    end
+
+    # Also check: if level_before + tokens_per_call would exceed capacity, the fillup should be rejected
+    # But if it was accepted, the actual level_after should be <= capacity (due to leakage or proper rejection)
+    # Use epsilon tolerance for floating point comparisons
+    suspicious_calls = accepted_calls.select do |c|
+      if c[:level_before] && c[:level_after]
+        would_exceed = (c[:level_before] + tokens_per_call) > bucket_capacity + epsilon
+        # If it would exceed but was accepted, check if level_after is still valid
+        # Use epsilon tolerance to account for floating point precision
+        would_exceed && c[:level_after] > bucket_capacity + epsilon
+      else
+        false
+      end
+    end
+
+    begin
+      assert_empty suspicious_calls,
+        "Found #{suspicious_calls.count} calls that were accepted when level_before + tokens would exceed capacity, " \
+        "AND level_after > capacity + #{epsilon} (epsilon tolerance). This indicates a race condition."
+    rescue Minitest::Assertion
+      # On failure, copy CSV to tmp/ directory for analysis
+      if File.exist?(log_file)
+        timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+        tmp_dir = File.join(__dir__, "..", "tmp")
+        FileUtils.mkdir_p(tmp_dir)
+        dest_file = File.join(tmp_dir, "concurrency_test_failure_#{timestamp}.csv")
+        FileUtils.cp(log_file, dest_file)
+        puts "\n=== CSV file copied to #{dest_file} for analysis ==="
+      end
+      raise
+    end
+
+    # Note: We don't assert on total_tokens_added because in a concurrent test with a leaky bucket,
+    # tokens leak continuously, allowing many more tokens to be added than capacity over time.
+    # The important check is that level never exceeds capacity (checked above), not the total tokens added.
+    # The final bucket level check below also verifies the bucket state is correct.
+
+    # Additional assertion: the final bucket level should not exceed capacity
+    # (accounting for some tokens that may have leaked during the test)
+    # Use epsilon tolerance to account for floating point precision
+    begin
+      assert_operator final_state.level, :<=, bucket_capacity + epsilon,
+        "Final bucket level should not exceed capacity. " \
+        "Expected at most #{bucket_capacity}, but got #{final_state.level.round(2)}. " \
+        "Using epsilon tolerance of #{epsilon} for floating point precision."
+    rescue Minitest::Assertion
+      copy_csv_on_failure(log_file)
+      raise
+    end
+
+    # Also verify that calls happened concurrently (within a reasonable time window)
+    if accepted_calls.any?
+      timestamps = accepted_calls.map { |c| c[:timestamp] }
+      time_span = timestamps.max - timestamps.min
+      puts "Time span of accepted calls: #{time_span.round(2)} seconds"
+
+      # Calls should complete within a reasonable time (not take minutes)
+      assert_operator time_span, :<, 30.0, "Calls should happen concurrently, not sequentially"
+    end
+  end
+end

--- a/test/leaky_bucket_concurrency_test_shared.rb
+++ b/test/leaky_bucket_concurrency_test_shared.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "csv"
+require "active_support/core_ext/numeric/time"
+
+module LeakyBucketConcurrencyTestShared
+  def copy_csv_on_failure(log_file)
+    if File.exist?(log_file)
+      timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+      tmp_dir = File.join(__dir__, "..", "tmp")
+      FileUtils.mkdir_p(tmp_dir)
+      dest_file = File.join(tmp_dir, "concurrency_test_failure_#{timestamp}.csv")
+      FileUtils.cp(log_file, dest_file)
+      puts "\n=== CSV file copied to #{dest_file} for analysis ==="
+    end
+  end
+
+  def run_concurrency_test(adapter:, setup_forked_process:)
+    # Configuration for testing
+    bucket_capacity = 500 # Small capacity for testing
+    over_time = 3.seconds
+    tokens_per_call = 5
+
+    # Calculate expected max calls
+    max_calls = bucket_capacity / tokens_per_call # 100 calls
+
+    # We'll try to make more calls than allowed, concurrently
+    # fillup_conditionally should reject calls that would exceed capacity
+    num_processes = 5
+    calls_per_process = 200 # Total: 1000 calls attempted, but only 100 should succeed
+
+    # Create a log file to track calls across processes
+    log_file = File.join(@test_dir, "calls.csv")
+    # Write CSV header
+    CSV.open(log_file, "w") do |csv|
+      csv << ["monotonic_time", "process_id", "call_id", "status", "level_before", "level_after"]
+    end
+
+    # Fork multiple processes that will make concurrent requests
+    pids = []
+
+    num_processes.times do |process_id|
+      pid = fork do
+        # Set up adapter in forked process (provided by the test)
+        forked_adapter = setup_forked_process.call
+
+        # Each process creates its own bucket instance
+        # They all share the same database/key, which is where the race condition occurs
+        bucket = Pecorino::LeakyBucket.new(
+          key: "concurrency_test_bucket",
+          capacity: bucket_capacity,
+          over_time: over_time,
+          adapter: forked_adapter
+        )
+
+        # Make many calls concurrently
+        calls_per_process.times do |call_id|
+          # Query the bucket state BEFORE the fillup to see what level it was at
+          state_before = bucket.state
+
+          # Try to add tokens conditionally
+          result = bucket.fillup_conditionally(tokens_per_call)
+
+          # Log the result with state before and after using CSV format
+          monotonic_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          row = [
+            monotonic_time,
+            process_id,
+            call_id,
+            result.accepted? ? "accepted" : "rejected",
+            state_before.level,
+            result.level
+          ]
+          File.open(log_file, "a") do |f|
+            f.flock(File::LOCK_EX)
+            f << CSV.generate_line(row)
+            f.flock(File::LOCK_UN)
+          end
+        rescue
+          # Log errors
+          monotonic_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          row = [
+            monotonic_time,
+            process_id,
+            call_id,
+            "error",
+            nil,
+            nil
+          ]
+          File.open(log_file, "a") do |f|
+            f.flock(File::LOCK_EX)
+            f << CSV.generate_line(row)
+            f.flock(File::LOCK_UN)
+          end
+        end
+
+        # Cleanup in forked process (if needed)
+        cleanup_forked_process if respond_to?(:cleanup_forked_process, true)
+      end
+
+      pids << pid
+    end
+
+    # Wait for all processes to complete
+    pids.each do |pid|
+      Process.wait(pid)
+    end
+
+    # Read and analyze the log file using CSV
+    calls = []
+
+    CSV.foreach(log_file, headers: true, header_converters: :symbol) do |row|
+      monotonic_time = row[:monotonic_time].to_f
+      process_id = row[:process_id].to_i
+      call_id = row[:call_id].to_i
+      status = row[:status]
+
+      if status == "error"
+        calls << {
+          timestamp: monotonic_time,
+          process_id: process_id,
+          call_id: call_id,
+          status: status,
+          level_before: nil,
+          level_after: nil,
+          level_or_error: nil
+        }
+      else
+        level_before = row[:level_before]&.to_f
+        level_after = row[:level_after]&.to_f
+
+        calls << {
+          timestamp: monotonic_time,
+          process_id: process_id,
+          call_id: call_id,
+          status: status,
+          level_before: level_before,
+          level_after: level_after,
+          level_or_error: level_after
+        }
+      end
+    end
+
+    # Sort calls by timestamp to see the progression
+    calls.sort_by! { |c| c[:timestamp] }
+
+    accepted_calls = calls.select { |c| c[:status] == "accepted" }
+
+    rejected_calls = calls.select { |c| c[:status] == "rejected" }
+
+    # Epsilon for floating point comparisons (accounting for precision and timing)
+    # We use a small tolerance to account for floating point arithmetic precision,
+    # database timestamp precision, and timing variations in concurrent operations.
+    # This prevents false positives from floating point rounding errors.
+    epsilon = 0.01
+
+    # Check that NO accepted call resulted in a level exceeding capacity
+    # Use epsilon tolerance to account for floating point precision
+    violations = accepted_calls.select { |c| c[:level_after] && c[:level_after] > bucket_capacity + epsilon }
+
+    # Also check if level_before + tokens_per_call would exceed capacity
+    # This catches cases where multiple transactions saw the same level_before
+    # Use epsilon tolerance for floating point comparisons
+    would_exceed_violations = accepted_calls.select do |c|
+      if c[:level_before] && c[:level_after]
+        would_exceed = (c[:level_before] + tokens_per_call) > bucket_capacity + epsilon
+        # But the actual level_after is less than capacity (due to leakage or rejection)
+        # Use epsilon tolerance here too
+        would_exceed && c[:level_after] <= bucket_capacity + epsilon
+      else
+        false
+      end
+    end
+
+    # Calculate actual tokens added by tracking level changes
+    # Note: This is approximate since tokens leak over time
+    # But we can verify the level never exceeds capacity
+    total_tokens_added = accepted_calls.count * tokens_per_call
+
+    # Check the final bucket level
+    final_bucket = Pecorino::LeakyBucket.new(
+      key: "concurrency_test_bucket",
+      capacity: bucket_capacity,
+      over_time: over_time,
+      adapter: adapter
+    )
+    final_state = final_bucket.state
+
+    # Calculate test duration to estimate leakage
+    test_duration = calls.any? ? (calls.last[:timestamp] - calls.first[:timestamp]) : 0
+    leak_rate = bucket_capacity / over_time.to_f
+    estimated_leakage = test_duration * leak_rate
+
+    puts "\n=== Test Results ==="
+    puts "Total accepted calls: #{accepted_calls.count}"
+    puts "Total rejected calls: #{rejected_calls.count}"
+    puts "Total tokens added (estimated): #{total_tokens_added} tokens"
+    puts "Bucket capacity: #{bucket_capacity} tokens"
+    puts "Expected max calls: #{max_calls}"
+    puts "Test duration: #{test_duration.round(2)} seconds"
+    puts "Estimated leakage during test: #{estimated_leakage.round(2)} tokens"
+    puts "Final bucket level: #{final_state.level.round(2)}"
+    puts "Final bucket full?: #{final_state.full?}"
+
+    if violations.any?
+      puts "\n=== VIOLATIONS DETECTED ==="
+      puts "Found #{violations.count} accepted calls that resulted in level > capacity:"
+      violations.first(10).each do |v|
+        puts "  Process #{v[:process_id]}, Call #{v[:call_id]}: level_before=#{v[:level_before]&.round(4)}, level_after=#{v[:level_after].round(4)} (capacity = #{bucket_capacity})"
+      end
+      puts "  ... (showing first 10)" if violations.count > 10
+    end
+
+    if would_exceed_violations.any?
+      puts "\n=== CALLS WHERE level_before + tokens WOULD EXCEED CAPACITY ==="
+      puts "Found #{would_exceed_violations.count} calls where queried level_before + tokens would exceed capacity"
+      puts "Note: These may be valid if tokens leaked between query and fillup execution"
+      would_exceed_violations.first(10).each do |v|
+        expected_level = v[:level_before] + tokens_per_call
+        actual_added = v[:level_after] - v[:level_before]
+        leaked = tokens_per_call - actual_added
+        puts "  Process #{v[:process_id]}, Call #{v[:call_id]}:"
+        puts "    Queried level_before: #{v[:level_before].round(4)}"
+        puts "    Expected if no leak: #{expected_level.round(4)} (would exceed!)"
+        puts "    Actual level_after: #{v[:level_after].round(4)} (valid: < #{bucket_capacity})"
+        puts "    Actual tokens added: #{actual_added.round(4)} (leaked: #{leaked.round(4)} during transaction)"
+      end
+      puts "  ... (showing first 10)" if would_exceed_violations.count > 10
+    end
+
+    # Show level progression for first few accepted calls
+    if accepted_calls.any?
+      puts "\n=== Level Progression (first 20 accepted calls) ==="
+      accepted_calls.first(20).each_with_index do |c, idx|
+        puts "  #{idx + 1}. Level before: #{c[:level_before] ? c[:level_before].round(4) : "N/A"}, after: #{c[:level_after] ? c[:level_after].round(4) : "N/A"}"
+      end
+
+      # Show calls near capacity
+      near_capacity = accepted_calls.select { |c| c[:level_after] && c[:level_after] > bucket_capacity * 0.9 }
+      if near_capacity.any?
+        puts "\n=== Calls Near Capacity (>90%) ==="
+        near_capacity.first(20).each do |c|
+          puts "  Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before]&.round(4)}, level_after=#{c[:level_after].round(4)} (#{(c[:level_after] / bucket_capacity * 100).round(2)}% of capacity)"
+        end
+      end
+
+      # Show the level before vs after for last 20 accepted calls
+      puts "\n=== Level Before vs After (last 20 accepted calls) ==="
+      accepted_calls.last(20).each do |c|
+        if c[:level_before] && c[:level_after]
+          would_exceed = (c[:level_before] + tokens_per_call) > bucket_capacity
+          margin = bucket_capacity - c[:level_before]
+          actual_added = c[:level_after] - c[:level_before]
+          puts "  Level before: #{c[:level_before].round(4)}, after: #{c[:level_after].round(4)}, margin: #{margin.round(4)}, would_exceed: #{would_exceed}, actual_added: #{actual_added.round(4)}"
+        end
+      end
+
+      # Find calls that were accepted when there was very little margin
+      # These are suspicious - multiple concurrent transactions might have all seen
+      # the same low margin and all accepted
+      # Use epsilon tolerance for floating point comparison
+      low_margin_calls = accepted_calls.select do |c|
+        if c[:level_before]
+          margin = bucket_capacity - c[:level_before]
+          margin < tokens_per_call * 2 + epsilon # Less than 2x tokens_per_call margin (with epsilon tolerance)
+        else
+          false
+        end
+      end
+
+      if low_margin_calls.any?
+        puts "\n=== Low Margin Calls (potential race condition) ==="
+        puts "Found #{low_margin_calls.count} calls accepted with margin < #{tokens_per_call * 2}"
+        low_margin_calls.each do |c|
+          margin = bucket_capacity - c[:level_before]
+          time_offset = c[:timestamp] - calls.first[:timestamp]
+          actual_added = c[:level_after] - c[:level_before]
+          puts "  Time: #{time_offset.round(4)}s, Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before].round(4)}, margin=#{margin.round(4)}, level_after=#{c[:level_after].round(4)}, actual_added=#{actual_added.round(4)}"
+        end
+
+        # Check if any low-margin calls happened at nearly the same time
+        if low_margin_calls.count > 1
+          timestamps = low_margin_calls.map { |c| c[:timestamp] }.sort
+          time_diffs = timestamps.each_cons(2).map { |a, b| b - a }
+          concurrent_pairs = time_diffs.count { |diff| diff < 0.01 } # Within 10ms
+          puts "  Concurrent low-margin calls (within 10ms): #{concurrent_pairs} pairs"
+
+          # Group by time windows to find concurrent calls
+          time_windows = low_margin_calls.group_by { |c| (c[:timestamp] * 100).floor / 100.0 } # Group by 10ms windows
+          concurrent_groups = time_windows.select { |_time, calls| calls.count > 1 }
+          if concurrent_groups.any?
+            puts "  Concurrent groups:"
+            concurrent_groups.each do |time_window, group_calls|
+              puts "    Time window #{time_window.round(4)}s: #{group_calls.count} calls"
+              group_calls.each do |c|
+                puts "      Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before].round(4)}, level_after=#{c[:level_after].round(4)}"
+              end
+            end
+          end
+        end
+      end
+    end
+
+    # KEY ASSERTION: fillup_conditionally should NEVER result in a level exceeding capacity
+    # This is the most important check - the bucket level after ANY accepted fillup
+    # must never exceed the capacity, regardless of concurrency.
+    begin
+      assert_empty violations,
+        "fillup_conditionally should NEVER allow the bucket level to exceed capacity. " \
+        "Found #{violations.count} violations where level_after > #{bucket_capacity} + #{epsilon} (epsilon tolerance). " \
+        "This indicates a race condition in Pecorino's fillup_conditionally implementation."
+    rescue Minitest::Assertion
+      copy_csv_on_failure(log_file)
+      raise
+    end
+
+    # Also check: if level_before + tokens_per_call would exceed capacity, the fillup should be rejected
+    # But if it was accepted, the actual level_after should be <= capacity (due to leakage or proper rejection)
+    # Use epsilon tolerance for floating point comparisons
+    suspicious_calls = accepted_calls.select do |c|
+      if c[:level_before] && c[:level_after]
+        would_exceed = (c[:level_before] + tokens_per_call) > bucket_capacity + epsilon
+        # If it would exceed but was accepted, check if level_after is still valid
+        # Use epsilon tolerance to account for floating point precision
+        would_exceed && c[:level_after] > bucket_capacity + epsilon
+      else
+        false
+      end
+    end
+
+    begin
+      assert_empty suspicious_calls,
+        "Found #{suspicious_calls.count} calls that were accepted when level_before + tokens would exceed capacity, " \
+        "AND level_after > capacity + #{epsilon} (epsilon tolerance). This indicates a race condition."
+    rescue Minitest::Assertion
+      copy_csv_on_failure(log_file)
+      raise
+    end
+
+    # Note: We don't assert on total_tokens_added because in a concurrent test with a leaky bucket,
+    # tokens leak continuously, allowing many more tokens to be added than capacity over time.
+    # The important check is that level never exceeds capacity (checked above), not the total tokens added.
+    # The final bucket level check below also verifies the bucket state is correct.
+
+    # Additional assertion: the final bucket level should not exceed capacity
+    # (accounting for some tokens that may have leaked during the test)
+    # Use epsilon tolerance to account for floating point precision
+    begin
+      assert_operator final_state.level, :<=, bucket_capacity + epsilon,
+        "Final bucket level should not exceed capacity. " \
+        "Expected at most #{bucket_capacity}, but got #{final_state.level.round(2)}. " \
+        "Using epsilon tolerance of #{epsilon} for floating point precision."
+    rescue Minitest::Assertion
+      copy_csv_on_failure(log_file)
+      raise
+    end
+
+    # Also verify that calls happened concurrently (within a reasonable time window)
+    if accepted_calls.any?
+      timestamps = accepted_calls.map { |c| c[:timestamp] }
+      time_span = timestamps.max - timestamps.min
+      puts "Time span of accepted calls: #{time_span.round(2)} seconds"
+
+      # Calls should complete within a reasonable time (not take minutes)
+      assert_operator time_span, :<, 30.0, "Calls should happen concurrently, not sequentially"
+    end
+  end
+end

--- a/test/leaky_bucket_concurrency_test_shared.rb
+++ b/test/leaky_bucket_concurrency_test_shared.rb
@@ -22,9 +22,6 @@ module LeakyBucketConcurrencyTestShared
     over_time = 3.seconds
     tokens_per_call = 5
 
-    # Calculate expected max calls
-    max_calls = bucket_capacity / tokens_per_call # 100 calls
-
     # We'll try to make more calls than allowed, concurrently
     # fillup_conditionally should reject calls that would exceed capacity
     num_processes = 5
@@ -147,8 +144,6 @@ module LeakyBucketConcurrencyTestShared
 
     accepted_calls = calls.select { |c| c[:status] == "accepted" }
 
-    rejected_calls = calls.select { |c| c[:status] == "rejected" }
-
     # Epsilon for floating point comparisons (accounting for precision and timing)
     # We use a small tolerance to account for floating point arithmetic precision,
     # database timestamp precision, and timing variations in concurrent operations.
@@ -159,25 +154,6 @@ module LeakyBucketConcurrencyTestShared
     # Use epsilon tolerance to account for floating point precision
     violations = accepted_calls.select { |c| c[:level_after] && c[:level_after] > bucket_capacity + epsilon }
 
-    # Also check if level_before + tokens_per_call would exceed capacity
-    # This catches cases where multiple transactions saw the same level_before
-    # Use epsilon tolerance for floating point comparisons
-    would_exceed_violations = accepted_calls.select do |c|
-      if c[:level_before] && c[:level_after]
-        would_exceed = (c[:level_before] + tokens_per_call) > bucket_capacity + epsilon
-        # But the actual level_after is less than capacity (due to leakage or rejection)
-        # Use epsilon tolerance here too
-        would_exceed && c[:level_after] <= bucket_capacity + epsilon
-      else
-        false
-      end
-    end
-
-    # Calculate actual tokens added by tracking level changes
-    # Note: This is approximate since tokens leak over time
-    # But we can verify the level never exceeds capacity
-    total_tokens_added = accepted_calls.count * tokens_per_call
-
     # Check the final bucket level
     final_bucket = Pecorino::LeakyBucket.new(
       key: "concurrency_test_bucket",
@@ -186,121 +162,6 @@ module LeakyBucketConcurrencyTestShared
       adapter: adapter
     )
     final_state = final_bucket.state
-
-    # Calculate test duration to estimate leakage
-    test_duration = calls.any? ? (calls.last[:timestamp] - calls.first[:timestamp]) : 0
-    leak_rate = bucket_capacity / over_time.to_f
-    estimated_leakage = test_duration * leak_rate
-
-    puts "\n=== Test Results ==="
-    puts "Total accepted calls: #{accepted_calls.count}"
-    puts "Total rejected calls: #{rejected_calls.count}"
-    puts "Total tokens added (estimated): #{total_tokens_added} tokens"
-    puts "Bucket capacity: #{bucket_capacity} tokens"
-    puts "Expected max calls: #{max_calls}"
-    puts "Test duration: #{test_duration.round(2)} seconds"
-    puts "Estimated leakage during test: #{estimated_leakage.round(2)} tokens"
-    puts "Final bucket level: #{final_state.level.round(2)}"
-    puts "Final bucket full?: #{final_state.full?}"
-
-    if violations.any?
-      puts "\n=== VIOLATIONS DETECTED ==="
-      puts "Found #{violations.count} accepted calls that resulted in level > capacity:"
-      violations.first(10).each do |v|
-        puts "  Process #{v[:process_id]}, Call #{v[:call_id]}: level_before=#{v[:level_before]&.round(4)}, level_after=#{v[:level_after].round(4)} (capacity = #{bucket_capacity})"
-      end
-      puts "  ... (showing first 10)" if violations.count > 10
-    end
-
-    if would_exceed_violations.any?
-      puts "\n=== CALLS WHERE level_before + tokens WOULD EXCEED CAPACITY ==="
-      puts "Found #{would_exceed_violations.count} calls where queried level_before + tokens would exceed capacity"
-      puts "Note: These may be valid if tokens leaked between query and fillup execution"
-      would_exceed_violations.first(10).each do |v|
-        expected_level = v[:level_before] + tokens_per_call
-        actual_added = v[:level_after] - v[:level_before]
-        leaked = tokens_per_call - actual_added
-        puts "  Process #{v[:process_id]}, Call #{v[:call_id]}:"
-        puts "    Queried level_before: #{v[:level_before].round(4)}"
-        puts "    Expected if no leak: #{expected_level.round(4)} (would exceed!)"
-        puts "    Actual level_after: #{v[:level_after].round(4)} (valid: < #{bucket_capacity})"
-        puts "    Actual tokens added: #{actual_added.round(4)} (leaked: #{leaked.round(4)} during transaction)"
-      end
-      puts "  ... (showing first 10)" if would_exceed_violations.count > 10
-    end
-
-    # Show level progression for first few accepted calls
-    if accepted_calls.any?
-      puts "\n=== Level Progression (first 20 accepted calls) ==="
-      accepted_calls.first(20).each_with_index do |c, idx|
-        puts "  #{idx + 1}. Level before: #{c[:level_before] ? c[:level_before].round(4) : "N/A"}, after: #{c[:level_after] ? c[:level_after].round(4) : "N/A"}"
-      end
-
-      # Show calls near capacity
-      near_capacity = accepted_calls.select { |c| c[:level_after] && c[:level_after] > bucket_capacity * 0.9 }
-      if near_capacity.any?
-        puts "\n=== Calls Near Capacity (>90%) ==="
-        near_capacity.first(20).each do |c|
-          puts "  Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before]&.round(4)}, level_after=#{c[:level_after].round(4)} (#{(c[:level_after] / bucket_capacity * 100).round(2)}% of capacity)"
-        end
-      end
-
-      # Show the level before vs after for last 20 accepted calls
-      puts "\n=== Level Before vs After (last 20 accepted calls) ==="
-      accepted_calls.last(20).each do |c|
-        if c[:level_before] && c[:level_after]
-          would_exceed = (c[:level_before] + tokens_per_call) > bucket_capacity
-          margin = bucket_capacity - c[:level_before]
-          actual_added = c[:level_after] - c[:level_before]
-          puts "  Level before: #{c[:level_before].round(4)}, after: #{c[:level_after].round(4)}, margin: #{margin.round(4)}, would_exceed: #{would_exceed}, actual_added: #{actual_added.round(4)}"
-        end
-      end
-
-      # Find calls that were accepted when there was very little margin
-      # These are suspicious - multiple concurrent transactions might have all seen
-      # the same low margin and all accepted
-      # Use epsilon tolerance for floating point comparison
-      low_margin_calls = accepted_calls.select do |c|
-        if c[:level_before]
-          margin = bucket_capacity - c[:level_before]
-          margin < tokens_per_call * 2 + epsilon # Less than 2x tokens_per_call margin (with epsilon tolerance)
-        else
-          false
-        end
-      end
-
-      if low_margin_calls.any?
-        puts "\n=== Low Margin Calls (potential race condition) ==="
-        puts "Found #{low_margin_calls.count} calls accepted with margin < #{tokens_per_call * 2}"
-        low_margin_calls.each do |c|
-          margin = bucket_capacity - c[:level_before]
-          time_offset = c[:timestamp] - calls.first[:timestamp]
-          actual_added = c[:level_after] - c[:level_before]
-          puts "  Time: #{time_offset.round(4)}s, Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before].round(4)}, margin=#{margin.round(4)}, level_after=#{c[:level_after].round(4)}, actual_added=#{actual_added.round(4)}"
-        end
-
-        # Check if any low-margin calls happened at nearly the same time
-        if low_margin_calls.count > 1
-          timestamps = low_margin_calls.map { |c| c[:timestamp] }.sort
-          time_diffs = timestamps.each_cons(2).map { |a, b| b - a }
-          concurrent_pairs = time_diffs.count { |diff| diff < 0.01 } # Within 10ms
-          puts "  Concurrent low-margin calls (within 10ms): #{concurrent_pairs} pairs"
-
-          # Group by time windows to find concurrent calls
-          time_windows = low_margin_calls.group_by { |c| (c[:timestamp] * 100).floor / 100.0 } # Group by 10ms windows
-          concurrent_groups = time_windows.select { |_time, calls| calls.count > 1 }
-          if concurrent_groups.any?
-            puts "  Concurrent groups:"
-            concurrent_groups.each do |time_window, group_calls|
-              puts "    Time window #{time_window.round(4)}s: #{group_calls.count} calls"
-              group_calls.each do |c|
-                puts "      Process #{c[:process_id]}, Call #{c[:call_id]}: level_before=#{c[:level_before].round(4)}, level_after=#{c[:level_after].round(4)}"
-              end
-            end
-          end
-        end
-      end
-    end
 
     # KEY ASSERTION: fillup_conditionally should NEVER result in a level exceeding capacity
     # This is the most important check - the bucket level after ANY accepted fillup
@@ -360,7 +221,6 @@ module LeakyBucketConcurrencyTestShared
     if accepted_calls.any?
       timestamps = accepted_calls.map { |c| c[:timestamp] }
       time_span = timestamps.max - timestamps.min
-      puts "Time span of accepted calls: #{time_span.round(2)} seconds"
 
       # Calls should complete within a reasonable time (not take minutes)
       assert_operator time_span, :<, 30.0, "Calls should happen concurrently, not sequentially"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "bundler"
+Bundler.setup
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "pecorino"
 


### PR DESCRIPTION
Under heavy load Pecorino is susceptible to a race condition where two things can happen:

* The CTE for the current bucket value selects a level of `NULL`, leading to a failure in the `UPDATE`
* The `UPDATE` may indicate lower bucket level than it actually is.

In Postgres, a CTE used with an `INSERT .. ON CONFLICT UPDATE` is not guaranteed to be atomic with the `UPDATE` itself. This means, that if there is _another_ fillup between the execution of the CTE (the `WITH (SELECT level FROM ...)` and the `UPDATE` - even if they are within the same statement - the fillup can get accepted. This makes Pecorino unsafe under high load when SQL-based rate limiting is used with PostgreSQL (the SQLite adapter will lock the entire database during update so it is much less of an issue there). Lesson from that is that a CTE used with an UPDATE is not atomic with that UPDATE, contrary to what I assumed when I designed it this way.

This also means that Pecorino needs proper row-level locking and a transaction around the fillups if the fillup may be rejected - as a formal way to block the concurrent fillups from taking place.

I have also updated the test config / a few other bits and bobs which were in the previous PRs.